### PR TITLE
Fix host binding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ server.post("/", async (request) => {
   return functionResult;
 });
 
-server.listen(8080, function (err, address) {
+server.listen(8080, '0.0.0.0', function (err, address) {
   if (err) {
     server.log.error(err);
     process.exit(1);


### PR DESCRIPTION
The web server currently binds to localhost only which will prevent port forwarding from the host machine to the container. This should be made configurable later.