### PR TITLE
Fix double JSON encoded return values

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -148,7 +148,7 @@ function makeResponse(
     .status(status)
     .header("x-extra-info", encodeURI(JSON.stringify(extraInfo)))
     .header("content-type", "application/json")
-    .send(JSON.stringify(data));
+    .send(data); // we don't JSON.stringify, as Fastify will do this for us (even for strings, because of content-type)
 }
 
 interface ExtraInfo {


### PR DESCRIPTION
`Reply.send` will JSON-encode the given data (even strings) if `Content-Type` is `application/json`; see https://www.fastify.io/docs/v1.13.x/Reply/#senddata

(tests coming in separate PR)