### PR TITLE
Remove Cloud Event type error in HTTP server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -44,19 +44,6 @@ export default function startServer<A>(
       return;
     }
 
-    if (
-      salesforceFunctionsCloudEvent.cloudEvent.type !==
-      "com.salesforce.function.invoke.sync"
-    ) {
-      makeResponse(
-        reply,
-        BAD_REQUEST_STATUS,
-        "CloudEvent must be of type 'com.salesforce.function.invoke.sync'!",
-        emptyExtraInfo
-      );
-      return;
-    }
-
     const parsedMimeType = mimetype.parse(
       salesforceFunctionsCloudEvent.cloudEvent.datacontenttype
     );


### PR DESCRIPTION
This currently creates issues for development environments because the cloud event type is different, so removing this until we can circle back and implement with dev env in mind.