### PR TITLE
Set Sforce-Call-Options header on requests made by the SDK

### DIFF
--- a/mappings/composite-create-tree.json
+++ b/mappings/composite-create-tree.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/composite-single-create-error.json
+++ b/mappings/composite-single-create-error.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/composite-single-create.json
+++ b/mappings/composite-single-create.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/composite-single-delete.json
+++ b/mappings/composite-single-delete.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/composite-single-query.json
+++ b/mappings/composite-single-query.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/composite-single-update.json
+++ b/mappings/composite-single-update.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/create-invalid-field.json
+++ b/mappings/create-invalid-field.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/create-invalid-picklist-value.json
+++ b/mappings/create-invalid-picklist-value.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/create-required-field-missing.json
+++ b/mappings/create-required-field-missing.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/create-unknown-object.json
+++ b/mappings/create-unknown-object.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/create.json
+++ b/mappings/create.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/delete-already-deleted.json
+++ b/mappings/delete-already-deleted.json
@@ -1,0 +1,37 @@
+{
+  "id": "89318fd8-a143-4ed8-ae88-0dfa8fabf875",
+  "name": "services_data_v510_sobjects_account_001b000001lp1g2iaj",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Account/001B000001Lp1G2IAJ",
+    "method": "DELETE",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response": {
+    "status": 404,
+    "body": "[{\"message\":\"entity is deleted\",\"errorCode\":\"ENTITY_IS_DELETED\",\"fields\":[]}]",
+    "headers": {
+      "Date": "Mon, 26 Apr 2021 14:18:56 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=VmToIKaaEeuzdBlvImoN0A; domain=.salesforce.com; path=/; expires=Tue, 26-Apr-2022 14:18:56 GMT; Max-Age=31536000",
+        "BrowserId_sec=VmToIKaaEeuzdBlvImoN0A; domain=.salesforce.com; path=/; expires=Tue, 26-Apr-2022 14:18:56 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=19/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "89318fd8-a143-4ed8-ae88-0dfa8fabf875",
+  "persistent": true,
+  "insertionIndex": 2
+}

--- a/mappings/delete.json
+++ b/mappings/delete.json
@@ -1,0 +1,36 @@
+{
+  "id": "38eb30ec-e4de-4aab-bbb4-7764a48f65bf",
+  "name": "services_data_v510_sobjects_account_001b000001lp1fxiaj",
+  "request": {
+    "url": "/services/data/v51.0/sobjects/Account/001B000001Lp1FxIAJ",
+    "method": "DELETE",
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response": {
+    "status": 204,
+    "headers": {
+      "Date": "Mon, 26 Apr 2021 14:09:10 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Content-Security-Policy": "upgrade-insecure-requests",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=-Nh_8qaYEeurzGfnXQ1IXQ; domain=.salesforce.com; path=/; expires=Tue, 26-Apr-2022 14:09:10 GMT; Max-Age=31536000",
+        "BrowserId_sec=-Nh_8qaYEeurzGfnXQ1IXQ; domain=.salesforce.com; path=/; expires=Tue, 26-Apr-2022 14:09:10 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=17/100000"
+    }
+  },
+  "uuid": "38eb30ec-e4de-4aab-bbb4-7764a48f65bf",
+  "persistent": true,
+  "insertionIndex": 1
+}

--- a/mappings/query-malformed-soql.json
+++ b/mappings/query-malformed-soql.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/query-unexpected-response.json
+++ b/mappings/query-unexpected-response.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/query-unknown-column.json
+++ b/mappings/query-unknown-column.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/query-with-next-records-url-2.json
+++ b/mappings/query-with-next-records-url-2.json
@@ -7,6 +7,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/query-with-next-records-url.json
+++ b/mappings/query-with-next-records-url.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/query.json
+++ b/mappings/query.json
@@ -12,6 +12,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/update-invalid-field.json
+++ b/mappings/update-invalid-field.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/update-malformed-id.json
+++ b/mappings/update-malformed-id.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/mappings/update.json
+++ b/mappings/update.json
@@ -14,6 +14,9 @@
     "headers": {
       "Authorization": {
         "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
       }
     }
   },

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -9,6 +9,7 @@ import {
   ReferenceId,
   UnitOfWork,
 } from "../sdk-interface-v1";
+import { version as ClientVersion } from "../../package.json";
 
 export class DataApiImpl implements DataApi {
   private readonly baseUrl: string;
@@ -28,6 +29,9 @@ export class DataApiImpl implements DataApi {
         accessToken: this.accessToken,
         instanceUrl: this.baseUrl,
         version: this.apiVersion,
+        callOptions: {
+          client: `sf-fx-runtime-nodejs-sdk-impl-v1:${ClientVersion}`,
+        },
       });
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     // "noUnusedParameters": true,
     "noImplicitReturns": true,
     "pretty": true,
-    "removeComments": true
+    "removeComments": true,
+    "resolveJsonModule": true,
   },
   "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
Sets the `Sforce-Call-Options` header using `jsforce`'s `callOptions`:
https://jsforce.github.io/jsforce/doc/Connection.html
https://github.com/jsforce/jsforce/blob/888edd0ff29d9b4926b16ee5bdacb9b99e773fb8/lib/http-api.js#L124-L130

...for parity with the Java SDK:
https://github.com/forcedotcom/sf-fx-runtime-java/blob/dda34cc6c617c84021dc417762a95e18b5438a07/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApi.java#L73

This also means the tests in this repo still pass when the latest Wiremock mappings from the Java invoker are synced to this repo:
https://github.com/forcedotcom/sf-fx-runtime-java/tree/main/sf-fx-runtime-java-sdk-impl-v1/src/test/resources/mappings

(I've synced all of the mappings; the newly added files are unused but will be required for new tests shortly. Note: I had to `s/java/nodejs/` for the client name used in the `Sforce-Call-Options` header, but otherwise the mappings are virtually identical aside from whitespace.)

In order to make the `package.json` import work, the [resolveJsonModule](https://www.typescriptlang.org/tsconfig#resolveJsonModule) TypeScript compiler option had to be enabled.

Refs GUS-W-9273089.