### PR TITLE
add next records url to output from queryMore

### DIFF
--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -83,6 +83,7 @@ export class DataApiImpl implements DataApi {
         done: response.done,
         totalSize: response.totalSize,
         records: response.records,
+        nextRecordsUrl: response.nextRecordsUrl
       };
     });
   }


### PR DESCRIPTION
I think every time a queryMore is performed that it probably returns the nextRecordsUlr from the payload for the next queryMore to use.