### PR TITLE
Tests: Fix the async error handling tests

### DIFF
--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -24,12 +24,14 @@ describe("DataApi Class", async () => {
 
     describe("invalid pick list value", async () => {
       it("throws invalid pick list error", async () => {
+        // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
         try {
           await dataApi.create({
             type: "Movie__c",
             Name: "Star Wars Episode VIII: The Last Jedi",
             Rating__c: "Terrible",
           });
+          expect.fail("Promise should have been rejected!")
         } catch (e) {
           expect(e.message).equal(
             "Rating: bad value for restricted picklist field: Terrible"
@@ -41,11 +43,13 @@ describe("DataApi Class", async () => {
 
     describe("unknown object type", async () => {
       it("throws a not found error", async () => {
+        // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
         try {
           await dataApi.create({
             type: "PlayingCard__c",
             Name: "Ace of Spades",
           });
+          expect.fail("Promise should have been rejected!")
         } catch (e) {
           expect(e.message).equal("The requested resource does not exist");
           expect(e.errorCode).equal("NOT_FOUND");
@@ -60,6 +64,7 @@ describe("DataApi Class", async () => {
             type: "Account",
             FavoritePet__c: "Dog",
           });
+          expect.fail("Promise should have been rejected!")
         } catch (e) {
           expect(e.message).equal(
             "No such column 'FavoritePet__c' on sobject of type Account"
@@ -71,11 +76,13 @@ describe("DataApi Class", async () => {
 
     describe("required field missing", async () => {
       it("throws missing field error", async () => {
+        // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
         try {
           await dataApi.create({
             type: "Spaceship__c",
             Name: "Falcon 9",
           });
+          expect.fail("Promise should have been rejected!")
         } catch (e) {
           expect(e.message).equal("Required fields are missing: [Website__c]");
           expect(e.errorCode).equal("REQUIRED_FIELD_MISSING");
@@ -139,8 +146,10 @@ describe("DataApi Class", async () => {
 
     describe("with unknown column", async () => {
       it("returns invalid field error", async () => {
+        // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
         try {
           await dataApi.query("SELECT Bacon__c FROM Account LIMIT 2");
+          expect.fail("Promise should have been rejected!")
         } catch (e) {
           expect(e.message).equal(
             "\nSELECT Bacon__c FROM Account LIMIT 2\n       ^\nERROR at Row:1:Column:8\nNo such column 'Bacon__c' on entity 'Account'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names."
@@ -152,8 +161,10 @@ describe("DataApi Class", async () => {
 
     describe("with malformed query", async () => {
       it("returns a malformed query error", async () => {
+        // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
         try {
           await dataApi.query("SELEKT Name FROM Account");
+          expect.fail("Promise should have been rejected!")
         } catch (e) {
           expect(e.errorCode).equal("MALFORMED_QUERY");
         }


### PR DESCRIPTION
Previously if the API did not reject the promise, the tests would still pass. Normally exception handling tests using Chai would be written using `expect(...).toThrow()` rather than try-catch, however Chai does not support promises or async natively.

One option would be to use [chai-as-promised](https://github.com/domenic/chai-as-promised) (which adds a new `.rejectedWith()` assertion, which is like `.toThrow` but for promises), however playing around with that the matchers for custom `Error` attributes (like `errorCode`) weren't great, so for now I've just added manual `fail()` calls to ensure the tests will actually fail if they don't reject/throw.

Longer term I would love to just switch to a test/assertion framework that is more modern and less bolted together (eg Jest + jest assertions).

Refs GUS-W-9279835.