### PR TITLE
Run the unit tests on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,27 @@ orbs:
 jobs:
   check-and-build:
     docker:
-      - image: cimg/node:14.17.0
+      # We need the JDK in order to run Wiremock.
+      - image: cimg/openjdk:11.0-node
     steps:
       - checkout
       - node/install-packages
+      - run:
+          name: Download Wiremock
+          command: curl -fL https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.28.0/wiremock-jre8-standalone-2.28.0.jar -o ~/wiremock.jar
+      - run:
+          name: Start Wiremock
+          command: java -jar ~/wiremock.jar --root-dir .
+          background: true
       - run:
           name: Run format check
           command: npm run format:check
       - run:
           name: Run linter
           command: npm run lint
+      - run:
+          name: Run unit tests
+          command: npm run test
       - run:
           name: Run docs build
           command: npm run docs


### PR DESCRIPTION
This adds the unit tests to the Circle CI configuration created in #34.

Whilst [Wiremock](http://wiremock.org/) has a docker image, on Circle CI you cannot easily run the `checkout` step on any "secondary containers", meaning that to get the `mappings` directory from the repository into the wiremock container we would have to do a custom docker build every time.

Another option would be to use [wiremock-captain](https://www.npmjs.com/package/wiremock-captain), however that does not support reading mappings from disk, so would require a fair bit of custom test support code.

Instead, we just run Wiremock in the same container as the tests, using the standalone JAR install method:
http://wiremock.org/docs/running-standalone/

Closes GUS-W-9282263.