### PR TITLE
Fix queryMore() when there are no more results

### DIFF
--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -76,6 +76,15 @@ export class DataApiImpl implements DataApi {
   }
 
   async queryMore(queryResult: RecordQueryResult): Promise<RecordQueryResult> {
+    if (!queryResult.nextRecordsUrl) {
+      return Promise.resolve({
+        done: queryResult.done,
+        totalSize: queryResult.totalSize,
+        records: [],
+        nextRecordsUrl: queryResult.nextRecordsUrl,
+      });
+    }
+
     return this.promisifyRequests(async (conn: Connection) => {
       const response = await conn.queryMore(queryResult.nextRecordsUrl);
 

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -257,11 +257,8 @@ describe("DataApi Class", async () => {
       });
     });
 
-    // This test currently fails due to jsforce making an unmocked request to:
-    // `/services/data/v51.0/sobjects//describe`
-    // TODO: W-9281153 - Make queryMore() return early if nextRecordsUrl is not defined.
-    describe.skip("with done results", async () => {
-      it("returns zero results", async () => {
+    describe("with done results", async () => {
+      it("returns zero records", async () => {
         const result = await dataApi.query("SELECT Name FROM Account");
         expect(result.done).equal(true);
         expect(result.totalSize).equal(5);


### PR DESCRIPTION
Previously `queryMore()` would try to make a request to the describe endpoint when `nextRecordUrl` was not defined.

Now an empty `RecordQueryResult` is returned straight away, for parity with the Java SDK implementation:
https://github.com/forcedotcom/sf-fx-runtime-java/blob/fc91d957ea59b9c7a4680400a098a61707d38b63/sf-fx-runtime-java-sdk-impl-v1/src/main/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImpl.java#L62-L71

Fixing this means the previously skipped test now passes.

Closes GUS-W-9281153.