### PR TITLE
Tests: Add more UnitOfWork SDK tests

### DIFF
--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -407,8 +407,29 @@ describe("DataApi Class", async () => {
           });
 
           const result = await dataApi.commitUnitOfWork(uow);
-
+          expect(result.size).equal(1);
           expect(result.get(rId).id).equal("a01B0000009gSoxIAE");
+        });
+
+        // TODO: W-9286866
+        it.skip("errors with bad value for picklist", async () => {
+          uow.registerCreate({
+            type: "Movie__c",
+            Name: "Star Wars Episode IV - A New Hope",
+            Rating__c: "Amazing",
+          });
+          // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
+          try {
+            await dataApi.commitUnitOfWork(uow);
+            expect.fail("Promise should have been rejected!");
+          } catch (e) {
+            expect(e.message).equal(
+              "Rating: bad value for restricted picklist field: Amazing"
+            );
+            expect(e.errorCode).equal(
+              "INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST"
+            );
+          }
         });
       });
 
@@ -421,6 +442,7 @@ describe("DataApi Class", async () => {
           });
           const result = await dataApi.commitUnitOfWork(uow);
 
+          expect(result.size).equal(1);
           expect(result.get(rId).id).equal("a01B0000009gSrFIAU");
         });
       });
@@ -430,6 +452,7 @@ describe("DataApi Class", async () => {
           const rId = uow.registerDelete("Movie__c", "a01B0000009gSr9IAE");
 
           const result = await dataApi.commitUnitOfWork(uow);
+          expect(result.size).equal(1);
           expect(result.get(rId).id).equal("a01B0000009gSr9IAE");
         });
       });
@@ -465,6 +488,19 @@ describe("DataApi Class", async () => {
           expect(result.get(rId1).id).equal("a00B000000FSkioIAD");
           expect(result.get(rId2).id).equal("a00B000000FSkipIAD");
           expect(result.get(rId3).id).equal("a00B000000FSkiqIAD");
+        });
+      });
+
+      // TODO: W-9286874
+      describe.skip("commitUnitOfWork with no registered operations", async () => {
+        it("throws a <to be determined> error", async () => {
+          // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
+          try {
+            await dataApi.commitUnitOfWork(uow);
+            expect.fail("Promise should have been rejected!");
+          } catch (e) {
+            expect(e.message).equal("TODO");
+          }
         });
       });
     });


### PR DESCRIPTION
These are the last of the tests missing compared to the Java UnitOfWork SDK tests:
https://github.com/forcedotcom/sf-fx-runtime-java/blob/991d6f096b3db41929d90d8a8e24240c026462b2/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/restapi/RestApiCompositeTest.java
https://github.com/forcedotcom/sf-fx-runtime-java/blob/991d6f096b3db41929d90d8a8e24240c026462b2/sf-fx-runtime-java-sdk-impl-v1/src/test/java/com/salesforce/functions/jvm/runtime/sdk/DataApiImplTest.java#L141-L239

I've found two potential bugs/issues - filed as:

- GUS-W-9286866: SDK's commitUnitOfWork() doesn't surface subrequest errors
- GUS-W-9286874: SDK's commitUnitOfWork() should gracefully handle there being no subrequests

I'll rebase this on `main` once #38 merges.

Closes GUS-W-9286893.