### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2021-5-20
 ### Changed
 - add `statusCode` to the `x-extra-info` header in HTTP responses ([#41](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/41))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-runtime-nodejs",
-  "version": "0.1.0-ea",
+  "version": "0.2.0",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## [0.2.0] - 2021-5-20
### Changed
- add `statusCode` to the `x-extra-info` header in HTTP responses ([#41](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/41))