### PR TITLE
Return early when committing empty UnitOfWork instances

### DIFF
--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -134,7 +134,7 @@ export class DataApiImpl implements DataApi {
       const subrequests = (unitOfWork as UnitOfWorkImpl).subrequests;
 
       if (subrequests.length === 0) {
-        return new Map();
+        return Promise.resolve(new Map());
       }
 
       const requestBody = {

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -132,6 +132,11 @@ export class DataApiImpl implements DataApi {
   ): Promise<Map<ReferenceId, RecordModificationResult>> {
     return this.promisifyRequests(async (conn: Connection) => {
       const subrequests = (unitOfWork as UnitOfWorkImpl).subrequests;
+
+      if (subrequests.length === 0) {
+        return new Map();
+      }
+
       const requestBody = {
         graphs: [
           {

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -524,16 +524,12 @@ describe("DataApi Class", async () => {
         });
       });
 
-      // TODO: W-9286874
-      describe.skip("commitUnitOfWork with no registered operations", async () => {
-        it("throws a <to be determined> error", async () => {
-          // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
-          try {
-            await dataApi.commitUnitOfWork(uow);
-            expect.fail("Promise should have been rejected!");
-          } catch (e) {
-            expect(e.message).equal("TODO");
-          }
+      describe("commitUnitOfWork with no registered operations", async () => {
+        it("should not make a composite graph API request and return an empty result", async () => {
+          // This will fail with a rejected promise if a request is being made since there won't be a wiremock mapping
+          // for an empty composite graph API request.
+          const result = await dataApi.commitUnitOfWork(uow);
+          expect(result.size).to.equal(0);
         });
       });
     });


### PR DESCRIPTION
This skips the actual request to the composite graph API. Initially, we thought we wanted to make this an error, but there is no need for an error here as we can handle this case gracefully without violating the API.

Closes [GUS-W-9286874](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000MAoqYAG/view)