### PR TITLE
Add error handling for UoW subrequests

### DIFF
--- a/src/sdk/unit-of-work.ts
+++ b/src/sdk/unit-of-work.ts
@@ -14,7 +14,10 @@ import {
 
 export class UnitOfWorkImpl implements UnitOfWork {
   private readonly apiVersion: string;
-  private readonly _subrequests: ReferenceIdSubrequestTuple[] = [];
+  private readonly _subrequests: [
+    ReferenceId,
+    CompositeSubRequest<RecordModificationResult>
+  ][] = [];
   private referenceIdCounter = 0;
 
   constructor(apiVersion: string) {
@@ -23,32 +26,29 @@ export class UnitOfWorkImpl implements UnitOfWork {
 
   registerCreate(record: RecordForCreate): ReferenceId {
     const referenceId = this.generateReferenceId();
-    this._subrequests.push({
-      referenceId,
-      subrequest: new CreateRecordSubRequest(record),
-    });
+    this._subrequests.push([referenceId, new CreateRecordSubRequest(record)]);
+
     return referenceId;
   }
 
   registerDelete(type: string, id: string): ReferenceId {
     const referenceId = this.generateReferenceId();
-    this._subrequests.push({
-      referenceId,
-      subrequest: new DeleteRecordSubRequest(type, id),
-    });
+    this._subrequests.push([referenceId, new DeleteRecordSubRequest(type, id)]);
+
     return referenceId;
   }
 
   registerUpdate(record: RecordForUpdate): ReferenceId {
     const referenceId = this.generateReferenceId();
-    this._subrequests.push({
-      referenceId,
-      subrequest: new UpdateRecordSubRequest(record),
-    });
+    this._subrequests.push([referenceId, new UpdateRecordSubRequest(record)]);
+
     return referenceId;
   }
 
-  get subrequests(): ReferenceIdSubrequestTuple[] {
+  get subrequests(): [
+    ReferenceId,
+    CompositeSubRequest<RecordModificationResult>
+  ][] {
     return this._subrequests;
   }
 
@@ -59,8 +59,3 @@ export class UnitOfWorkImpl implements UnitOfWork {
     return referenceId;
   }
 }
-
-export type ReferenceIdSubrequestTuple = {
-  referenceId: ReferenceId;
-  subrequest: CompositeSubRequest<RecordModificationResult>;
-};

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -436,12 +436,13 @@ describe("DataApi Class", async () => {
           expect(result.get(rId).id).equal("a01B0000009gSoxIAE");
         });
 
-        // TODO: W-9286866
-        it.skip("errors with bad value for picklist", async () => {
+        it("errors with bad value for picklist", async () => {
           uow.registerCreate({
             type: "Movie__c",
-            Name: "Star Wars Episode IV - A New Hope",
-            Rating__c: "Amazing",
+            fields: {
+              Name: "Star Wars Episode IV - A New Hope",
+              Rating__c: "Amazing",
+            },
           });
           // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
           try {
@@ -449,10 +450,7 @@ describe("DataApi Class", async () => {
             expect.fail("Promise should have been rejected!");
           } catch (e) {
             expect(e.message).equal(
-              "Rating: bad value for restricted picklist field: Amazing"
-            );
-            expect(e.errorCode).equal(
-              "INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST"
+              "INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST: Rating: bad value for restricted picklist field: Amazing"
             );
           }
         });


### PR DESCRIPTION
- Allow `CompositeSubRequest` implementations to yield errors when processing a response
- Add error handling for all `CompositeSubRequest` implementations
- Remove `ReferenceIdSubrequestTuple` type and use TypeScript tuples instead (i.e.: `[ReferenceId, RecordModificationResult]`)
- Handle errors in `DataApi.commitUnitOfWork` and expose them with the returned `Promise`
- Re-enable test for subrequest error handling

Closes [GUS-W-9286866](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000MAoCYAW/view)