### PR TITLE
Fix Salesforce API version to 51.0

### DIFF
--- a/src/sdk/org.ts
+++ b/src/sdk/org.ts
@@ -16,7 +16,7 @@ export class OrgImpl implements Org {
   readonly user: User;
 
   constructor(
-    { apiVersion }: SalesforceContext,
+    salesforceContext: SalesforceContext,
     { accessToken }: SalesforceFunctionContext,
     {
       orgId,
@@ -30,7 +30,11 @@ export class OrgImpl implements Org {
     this.id = orgId;
     this.baseUrl = salesforceBaseUrl;
     this.domainUrl = orgDomainUrl;
-    this.apiVersion = apiVersion;
+
+    // An API version is also available in SalesforceContext. That value differs
+    // between orgs and can change seemingly randomly. To avoid surprises at runtime, we
+    // intentionally don't use that value and instead fix the version.
+    this.apiVersion = "51.0";
 
     this.dataApi = new DataApiImpl(this.baseUrl, this.apiVersion, accessToken);
     this.user = new UserImpl(userId, username, onBehalfOfUserId);


### PR DESCRIPTION
Fix Salesforce API version to `51.0`. Tests already used `51.0`, so no test changes necessary.

Closes [GUS-W-9534842](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000PukdYAC/view)