### PR TITLE
Remove caseInsensitiveIdMap

### DIFF
--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -11,7 +11,6 @@ import {
 } from "sf-fx-sdk-nodejs";
 import { version as ClientVersion } from "../../package.json";
 import { createCaseInsensitiveRecord } from "../utils/maps";
-import { createCaseInsensitiveIdMap } from "../utils/maps";
 
 export class DataApiImpl implements DataApi {
   private readonly baseUrl: string;
@@ -108,13 +107,20 @@ export class DataApiImpl implements DataApi {
     recordUpdate: RecordForUpdate
   ): Promise<RecordModificationResult> {
     return this.promisifyRequests(async (conn: Connection) => {
-      const fields = createCaseInsensitiveIdMap(recordUpdate.fields);
-      const params = Object.assign({}, fields, {
-        Id: fields.id,
+      // Normalize the "id" field casing. jsforce requires an "Id" field, whereas
+      // our SDK definition requires customers to provide "id". Customers that are not using TS might also
+      // pass other casings for the "id" field ("iD", "ID"). Any other fields are passed to the Salesforce API untouched.
+      const fields = { ...recordUpdate.fields };
+      Object.keys(fields).forEach((key) => {
+        if (key.toLowerCase() === "id") {
+          const value = fields[key];
+          delete fields[key];
+
+          fields.Id = value;
+        }
       });
 
-      delete params.id;
-      const response: any = await conn.update(recordUpdate.type, params);
+      const response: any = await conn.update(recordUpdate.type, fields);
       return { id: response.id };
     });
   }

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -110,14 +110,12 @@ export class DataApiImpl implements DataApi {
       // Normalize the "id" field casing. jsforce requires an "Id" field, whereas
       // our SDK definition requires customers to provide "id". Customers that are not using TS might also
       // pass other casings for the "id" field ("iD", "ID"). Any other fields are passed to the Salesforce API untouched.
-      const fields = { ...recordUpdate.fields };
-      Object.keys(fields).forEach((key) => {
-        if (key.toLowerCase() === "id") {
-          const value = fields[key];
-          delete fields[key];
+      const fields = { Id: null };
+      Object.keys(recordUpdate.fields).forEach((key) => {
+        const value = recordUpdate.fields[key];
+        const targetKey = key.toLowerCase() === "id" ? "Id" : key;
 
-          fields.Id = value;
-        }
+        fields[targetKey] = value;
       });
 
       const response: any = await conn.update(recordUpdate.type, fields);

--- a/src/utils/maps.ts
+++ b/src/utils/maps.ts
@@ -12,31 +12,6 @@ const mapHandler = {
   },
 };
 
-const CaseInsensitiveIdMapHandler = {
-  get(obj: any, prop: string | symbol): any {
-    const key = prop.toString().toLowerCase();
-    if (key === "id") {
-      return obj[key];
-    } else {
-      return obj[prop];
-    }
-  },
-
-  set(obj: any, prop: string | symbol, value: any): boolean {
-    const key = prop.toString().toLowerCase();
-    if (key === "id") {
-      if (obj[key]) {
-        throw new Error("Duplicate id property");
-      }
-
-      obj[key] = value;
-    } else {
-      obj[prop] = value;
-    }
-    return true;
-  },
-};
-
 export function createCaseInsensitiveRecord(record: any): Record {
   const fields = createCaseInsensitiveMap(record);
   const type = record.attributes.type;
@@ -51,13 +26,6 @@ export function createCaseInsensitiveRecord(record: any): Record {
 
 export function createCaseInsensitiveMap(map: any): any {
   const fields = new Proxy({}, mapHandler);
-  Object.keys(map).forEach((key) => (fields[key] = map[key]));
-
-  return fields;
-}
-
-export function createCaseInsensitiveIdMap(map: any): any {
-  const fields = new Proxy({}, CaseInsensitiveIdMapHandler);
   Object.keys(map).forEach((key) => (fields[key] = map[key]));
 
   return fields;

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -301,6 +301,8 @@ describe("DataApi Class", async () => {
           ["id", "Id", "iD", "ID"].map(async (idProp) => {
             const { id } = await dataApi.update({
               type: "Movie__c",
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
               fields: {
                 [idProp]: "a00B000000FSjVUIA1",
                 ReleaseDate__c: "1980-05-21",

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -296,20 +296,20 @@ describe("DataApi Class", async () => {
         expect(id).equal("a00B000000FSjVUIA1");
       });
 
-      it("accepts any casing of id", async () => {
-        ["Id", "iD", "ID"].forEach(async (idProp) => {
-          const fields = {};
-          fields[idProp] = "a00B000000FSjVUIA1";
-          fields["ReleaseDate__c"] = "1980-05-21";
-          const { id } = await dataApi.update({
-            type: "Movie__c",
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            fields: fields,
-          });
+      it("accepts any casing of id", () => {
+        return Promise.all(
+          ["id", "Id", "iD", "ID"].map(async (idProp) => {
+            const { id } = await dataApi.update({
+              type: "Movie__c",
+              fields: {
+                [idProp]: "a00B000000FSjVUIA1",
+                ReleaseDate__c: "1980-05-21",
+              },
+            });
 
-          expect(id).equal("a00B000000FSjVUIA1");
-        });
+            expect(id).equal("a00B000000FSjVUIA1");
+          })
+        );
       });
     });
 

--- a/test/utils/maps.ts
+++ b/test/utils/maps.ts
@@ -1,28 +1,5 @@
 import { expect } from "chai";
 import { createCaseInsensitiveMap } from "../../src/utils/maps";
-import { createCaseInsensitiveIdMap } from "../../src/utils/maps";
-
-describe("createCaseInsensitiveIdMap", async () => {
-  it("creates case insensitive id properties", async () => {
-    expect(createCaseInsensitiveIdMap({ id: "Cinco" }).id).to.equal("Cinco");
-    expect(createCaseInsensitiveIdMap({ Id: "Cinco" }).id).to.equal("Cinco");
-    expect(createCaseInsensitiveIdMap({ ID: "Cinco" }).id).to.equal("Cinco");
-    expect(createCaseInsensitiveIdMap({ iD: "Cinco" }).id).to.equal("Cinco");
-
-    try {
-      createCaseInsensitiveIdMap({ iD: "Cinco", id: "river" });
-    } catch (e) {
-      expect(e.message).equal("Duplicate id property");
-    }
-
-    expect(createCaseInsensitiveIdMap({ sPecIes: "dog" }).sPecIes).to.equal(
-      "dog"
-    );
-    expect(createCaseInsensitiveIdMap({ sPecIes: "dog" }).species).to.equal(
-      undefined
-    );
-  });
-});
 
 describe("createCaseInsensitiveMap", async () => {
   const object = {


### PR DESCRIPTION
Removes `caseInsensitiveIdMap` introduced by #54.

It was only used in one place, is a very specific solution to a specific problem but tries to be something generic. That's also why the naming was a little off. I replaced it with a couple of lines at the one place where `caseInsensitiveIdMap` was used. I also added a comment why this normalization needs to happen.

In addition, this PR fixes the "accepts any casing of id" test. The previous implementation ignored the outcome of the individual promises created by `forEach`. When one of the Promises would have failed we would've gotten an unhandled promise rejection error.

When I noticed the issues in #54, the PR was already merged. Otherwise I would've left a comment.