### PR TITLE
Test server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import * as fastify from "fastify";
-import { FastifyReply } from "fastify";
+import { FastifyReply, FastifyInstance } from "fastify";
 import { LoggerImpl } from "./user-function-logger";
 import { parseCloudEvent, SalesforceFunctionsCloudEvent } from "./cloud-event";
 import { performance } from "perf_hooks";
@@ -14,11 +14,9 @@ const BAD_REQUEST_STATUS = 400;
 const INTERNAL_SERVER_ERROR_STATUS = 500;
 const SERVICE_UNAVAILABLE_STATUS = 503;
 
-export default function startServer(
-  host: string,
-  port: number,
+export function buildServer(
   userFunction: SalesforceFunction<any, any>
-): void {
+): FastifyInstance {
   const server = fastify.fastify({ logger: false });
 
   server.post("/", async (request, reply) => {
@@ -117,6 +115,15 @@ export default function startServer(
     });
   });
 
+  return server;
+}
+
+export default function startServer(
+  host: string,
+  port: number,
+  userFunction: SalesforceFunction<any, any>
+): void {
+  const server = buildServer(userFunction);
   server.listen(port, host, function (err) {
     if (err) {
       server.log.error(err);

--- a/test/server.ts
+++ b/test/server.ts
@@ -1,0 +1,92 @@
+import { expect } from "chai";
+import { buildServer } from "../src/server";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const userFunction = async function (event, context, logger) {
+  return "Hello World";
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const badFunction = async function (event, context, logger) {
+  throw "bad";
+};
+
+const cloudEventHeaders = {
+  "content-type": "application/json; charset=utf-8",
+  "ce-id": "fe9da89b-1eed-471c-a04c-0b3c664b63af",
+  "ce-time": "2021-07-29T20:35:46.910Z",
+  "ce-type": "com.salesforce.function.invoke.sync",
+  "ce-source": "urn:sf-fx-runtime-nodejs:testing",
+  "ce-specversion": "1.0",
+  "ce-sfcontext":
+    "eyJhcGlWZXJzaW9uIjoiNTAuMCIsInBheWxvYWRWZXJzaW9uIjoiMC4xIiwidXNlckNvbnRleHQiOnsib3JnSWQiOiIwMER4eDAwMDAwMDZJWUoiLCJ1c2VySWQiOiIwMDV4eDAwMDAwMVg4VXoiLCJvbkJlaGFsZk9mVXNlcklkIjpudWxsLCJ1c2VybmFtZSI6InRlc3QtenFpc25mNnl0bHF2QGV4YW1wbGUuY29tIiwic2FsZXNmb3JjZUJhc2VVcmwiOiJodHRwOi8vcGlzdGFjaGlvLXZpcmdvLTEwNjMtZGV2LWVkLmxvY2FsaG9zdC5pbnRlcm5hbC5zYWxlc2ZvcmNlLmNvbTo2MTA5Iiwib3JnRG9tYWluVXJsIjoiaHR0cDovL3Bpc3RhY2hpby12aXJnby0xMDYzLWRldi1lZC5sb2NhbGhvc3QuaW50ZXJuYWwuc2FsZXNmb3JjZS5jb206NjEwOSJ9fQ==",
+  "ce-sffncontext":
+    "eyJhY2Nlc3NUb2tlbiI6IjAwRHh4MDAwMDAwNklZSiFBUUVBUU5SYWM1YTFoUmhoZjAySFJlZ3c0c1NadktoOW9ZLm9oZFFfYV9LNHg1ZHdBZEdlZ1dlbVhWNnBOVVZLaFpfdVkyOUZ4SUVGTE9adTBHZjlvZk1HVzBIRkxacDgiLCJmdW5jdGlvbkludm9jYXRpb25JZCI6bnVsbCwiZnVuY3Rpb25OYW1lIjoiTXlGdW5jdGlvbiIsImFwZXhDbGFzc0lkIjpudWxsLCJhcGV4Q2xhc3NGUU4iOm51bGwsInJlcXVlc3RJZCI6IjAwRHh4MDAwMDAwNklZSkVBMi00WTRXM0x3X0xrb3NrY0hkRWFaemUtLU15RnVuY3Rpb24tMjAyMC0wOS0wM1QyMDo1NjoyNy42MDg0NDRaIiwicmVzb3VyY2UiOiJodHRwOi8vZGhhZ2Jlcmctd3NsMTo4MDgwIn0",
+};
+
+describe("server", () => {
+  it("checks health", () => {
+    buildServer(userFunction).inject(
+      {
+        method: "POST",
+        url: "/",
+        headers: { "x-health-check": "true" },
+      },
+      (err, response) => {
+        expect(response.statusCode).equal(200);
+      }
+    );
+  });
+
+  it("adds extra info to a user thrown function error", () => {
+    buildServer(badFunction).inject(
+      {
+        method: "POST",
+        url: "/",
+        headers: cloudEventHeaders,
+        payload: "{}",
+      },
+      (err, response) => {
+        expect(response.body).equal("Function threw: bad");
+
+        const extraInfo = JSON.parse(
+          decodeURI(response.headers["x-extra-info"].toString())
+        );
+        expect(extraInfo.isFunctionError).equal(true);
+        expect(extraInfo.stack).equal("");
+
+        expect(response.statusCode).equal(500);
+      }
+    );
+  });
+
+  it("receives a valid response from valid cloudEventHeaders", () => {
+    buildServer(userFunction).inject(
+      {
+        method: "POST",
+        url: "/",
+        headers: cloudEventHeaders,
+        payload: "{}",
+      },
+      (err, response) => {
+        expect(response.body).equal('"Hello World"');
+        expect(response.statusCode).equal(200);
+      }
+    );
+  });
+
+  it("returns 400 on missing cloud event", () => {
+    buildServer(userFunction).inject(
+      {
+        method: "POST",
+        url: "/",
+      },
+      (err, response) => {
+        expect(response.body).equal(
+          "Could not parse CloudEvent: no cloud event detected"
+        );
+        expect(response.statusCode).equal(400);
+      }
+    );
+  });
+});


### PR DESCRIPTION
GUS-W-9467188

This commit decouples building the server from starting the server so that it can be invoked in a headless testing environment using inject [Fastify testing docs](https://www.fastify.io/docs/latest/Testing/#benefits-of-using-fastifyinject).

I tested the major branches. One I wasn't able to execute was to get to this error state https://github.com/forcedotcom/sf-fx-runtime-nodejs/blob/30ad8a0beb09b69c21961db332aa62dd4ba4025c/src/server.ts#L57. The CloudEvents library parses the headers and body with a json parser. If you try to pass in something that might not have an encoding as json it seems to not be able to make it this far. 

Here's an example (failing) test:

```
// Uncaught AssertionError: expected 'Could not parse CloudEvent: Unexpected end of JSON input' // to equal 'CloudEvent data must be of type application/json!'
// + expected - actual
// 
// -Could not parse CloudEvent: Unexpected end of JSON input
// +CloudEvent data must be of type application/json!
it("raises invalid application/json error", () => {
  const headers = Object.assign({},  cloudEventHeaders);
  headers['ce-sfcontext'] = "";
  // headers['ce-sffncontext'] = "";
  buildServer(userFunction).inject(
    {
      method: "POST",
      url: "/",
      headers: headers,
      payload: "{}"
    },
    (err, response) => {
      console.log(response);
      expect(response.body).equal("CloudEvent data must be of type application/json!")
      expect(response.statusCode).equal(400);
    }
  );
});
```

This branch was introduced in https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/18. It references this work item https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000BCyVYAW/view which references this commit in java https://github.com/forcedotcom/sf-fx-runtime-java/blob/3d2ad24ccf1f67fd8778c430066056d06885d118/sf-fx-runtime-java-runtime/src/main/java/com/salesforce/functions/jvm/runtime/invocation/undertow/UndertowInvocationInterface.java with the same error message "CloudEvent data must be of type application/json". Which was then refactored out in https://github.com/forcedotcom/sf-fx-runtime-java/commit/9b395a8c08362194e6b5f157cb0dcfcd6282500e#diff-10f82bda7c14021879b952d4ee43a39baf3759d143f1f4ffc6757921b00e7c7e.

That line was added in https://github.com/forcedotcom/sf-fx-runtime-java/commit/cafebabefa1345fc9c029e08f1e2cfb77d6e2b44 initially which didn't come with a test to hint as to how to invoke that error state. It seems it might be unreachable in this invoker.

## Alternatives

The biggest change here is the refactor to expose the fastify object needed to call `inject`. We could change the name here, we could also try to expose it as an interface rather than a function. I'm not sure the impacts of exporting this function beyond exposing it to tests.