### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @forcedotcom/languages


### PR DESCRIPTION
While reviewing #99, I noticed all team members being added individually as reviewers. Most, if not all, of our other repositories have a `CODEOWNERS` file and appropriate settings to auto-request a review from the languages team. This repository wasn't set up for this yet. This PR adds the missing `CODEOWNERS` file.

I also changed the repository configuration accordingly.