### PR TITLE
Release v0.3.0-ea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0-ea] - 2021-08-20
+
 - Add Support for functions using JavaScript Modules / ESM ([#99](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/99))
 
 ## [0.1.2-ea] - 2021-07-27

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-runtime-nodejs",
-  "version": "0.1.2-ea",
+  "version": "0.3.0-ea",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const { readFile, readFileSync, writeFileSync } = require("node:fs");
-const { exec } = require('child_process');
+import { readFile, readFileSync, writeFileSync } from "fs";
+import { exec } from "child_process";
 const version = process.argv[2];
 
 const semver = new RegExp(/^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)$/);


### PR DESCRIPTION
Let's release #99 as v0.3.0-ea. Note that we're going from `0.1.2-ea` to `0.3.0-ea`. I'm skipping`0.2.0` because [it's already been tagged in our history](https://github.com/forcedotcom/sf-fx-runtime-nodejs/releases/tag/v0.2.0).