### PR TITLE
Import package.json to ensure it ends up in compiled output.

### DIFF
--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -1,7 +1,4 @@
 import { Connection } from "jsforce/lib/connection.js";
-import { readFileSync } from "fs";
-import { join } from "path";
-import { fileURLToPath } from "url";
 import { UnitOfWorkImpl } from "./unit-of-work.js";
 import {
   DataApi,
@@ -13,15 +10,8 @@ import {
   UnitOfWork,
 } from "sf-fx-sdk-nodejs";
 import { createCaseInsensitiveRecord } from "../utils/maps.js";
-const pkgPath = join(
-  fileURLToPath(import.meta.url),
-  "..",
-  "..",
-  "..",
-  "package.json"
-);
-const pkg = readFileSync(pkgPath, "utf8");
-const ClientVersion = JSON.parse(pkg).version;
+import pkg from "../../package.json";
+const ClientVersion = pkg.version;
 
 export class DataApiImpl implements DataApi {
   private readonly baseUrl: string;


### PR DESCRIPTION
There are CI failures in https://github.com/heroku/buildpacks-nodejs/pull/114. These failures are from a subtlety in `tsc` and the changes in #99.

In #99, we stopped importing this project's `package.json` directly with `require`, instead relying on `fs` calls (because `require("package.json")` is a CommonJS syntax that isn't supported in JavaScript Modules). The side effect is that Typescript detected that we no longer needed the `package.json` at runtime, so `package.json` is not included in the `dist/` build output. As a result the code that reads expects the `package.json` to exist crashes at runtime.

Typescript does provide an alternative to the `require("package.json")` in `import pkg from "package.json"`. Using that syntax also allows Typescript to recognize that `package.json` is required and moves it into the build output.

Note that this does duplicate `package.json` in the npm package output. It's present at `/` and `/dist`. I've looked into referencing the `package.json` at `/`, but was blocked because typescript and our typescript repl used during tests (ts-node/esm) don't agree about relative paths.