### PR TITLE
Change tsc build output to dist/ from dist/src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist/
 docs/
 node_modules/
+tsconfig.tsbuildinfo
 .idea
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Compiled source files now live in `dist/` rather than `dist/src/`
+  ([#114](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/114)
+
 ## [0.3.1] - 2021-08-23
 - Wiremock Java installation no longer required for testing ([#104](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/104))
 

--- a/bin/invoke.js
+++ b/bin/invoke.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import("../dist/src/index.js");
+import("../dist/index.js");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es2020",
     "outDir": "./dist",
     "baseUrl": ".",
-    "rootDir": "./",
+    "rootDir": "./src",
     "target": "es2017",
     "lib": ["es2017", "dom"],
     "allowSyntheticDefaultImports": true,
@@ -14,8 +14,7 @@
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "pretty": true,
-    "removeComments": true,
-    "resolveJsonModule": true
+    "removeComments": true
   },
   "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
There are CI failures in https://github.com/heroku/buildpacks-nodejs/pull/114. These failures are from a subtlety in `tsc` and the changes in #99.

In #99, we stopped importing this project's `package.json` directly with `require`, instead relying on `fs` calls (because `require("package.json")` is a CommonJS syntax that isn't supported in JavaScript Modules). The side effect is that Typescript detected that we no longer needed the `package.json` at runtime, so `package.json` is not included in the `dist/` build output. Since we have code that expects the `package.json` at a relative location, but compiled files are nested deeper in `dist/src/`, the tests pass, but integration tests don't.

This is an alternative fix to #113, where instead of re-including the package.json in the old location, we drop the nested structure in the compiled output. Instead of `dist/src/index.js`, compiled assets live at `dist/index.js`. This allows the distance between a `src` file and a `dist` file and the package.json to be the same.
