### PR TITLE
Automatic ReferenceID expansion via `toApiString()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Automatically expand ReferenceIDs with `.toApiString()` ([#133](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/133))
 - Add unit testing for src/index.ts ([#118](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/118))
 - Utilize @salesforce/core for logging with logfmt ([#119](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/119))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-plugin-license-header": "^0.2.0",
         "mocha": "^9.1.1",
         "prettier": "^2.3.2",
-        "sf-fx-sdk-nodejs": "^2.1.1",
+        "sf-fx-sdk-nodejs": "^3.0.0",
         "sinon": "^11.1.2",
         "ts-node": "^10.2.1",
         "typedoc": "^0.21.9",
@@ -4348,9 +4348,9 @@
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
     },
     "node_modules/sf-fx-sdk-nodejs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sf-fx-sdk-nodejs/-/sf-fx-sdk-nodejs-2.1.1.tgz",
-      "integrity": "sha512-yhR3i7RMhYPzuE452hwaexCS+inpGXDpipfBFZKfuWDTRMl9LYFVpEOZABOuIHQddKU0cGbew14TQJeNvD9TOw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sf-fx-sdk-nodejs/-/sf-fx-sdk-nodejs-3.0.0.tgz",
+      "integrity": "sha512-5mW5A8vZhqrUNNLZMlWvgyjIFast6jvkIp/3Y38Apk+/bAdsW4380xoLsW0s/HPJPwZU0/weApHPaUn2U7l7Vw==",
       "dev": true
     },
     "node_modules/sfdx-faye": {
@@ -8620,9 +8620,9 @@
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg=="
     },
     "sf-fx-sdk-nodejs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sf-fx-sdk-nodejs/-/sf-fx-sdk-nodejs-2.1.1.tgz",
-      "integrity": "sha512-yhR3i7RMhYPzuE452hwaexCS+inpGXDpipfBFZKfuWDTRMl9LYFVpEOZABOuIHQddKU0cGbew14TQJeNvD9TOw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sf-fx-sdk-nodejs/-/sf-fx-sdk-nodejs-3.0.0.tgz",
+      "integrity": "sha512-5mW5A8vZhqrUNNLZMlWvgyjIFast6jvkIp/3Y38Apk+/bAdsW4380xoLsW0s/HPJPwZU0/weApHPaUn2U7l7Vw==",
       "dev": true
     },
     "sfdx-faye": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-license-header": "^0.2.0",
     "mocha": "^9.1.1",
     "prettier": "^2.3.2",
-    "sf-fx-sdk-nodejs": "^2.1.1",
+    "sf-fx-sdk-nodejs": "^3.0.0",
     "sinon": "^11.1.2",
     "ts-node": "^10.2.1",
     "typedoc": "^0.21.9",

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -9,7 +9,7 @@ import { Connection } from "jsforce2/lib/connection.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
-import { ReferenceIdImpl, UnitOfWorkImpl } from "./unit-of-work.js";
+import { UnitOfWorkImpl } from "./unit-of-work.js";
 import {
   DataApi,
   RecordForCreate,
@@ -195,17 +195,21 @@ export class DataApiImpl implements DataApi {
       > = Promise.all(
         requestResult.graphs[0].graphResponse.compositeResponse.map(
           (compositeResponse) => {
-            const subrequest = subrequests.find(([subrequestReferenceId]) =>
-                subrequestReferenceId.toString() === compositeResponse.referenceId
+            const subrequest = subrequests.find(
+              ([subrequestReferenceId]) =>
+                subrequestReferenceId.toString() ===
+                compositeResponse.referenceId
             );
-            return subrequest[1].processResponse(
-              compositeResponse.httpStatusCode,
-              compositeResponse.httpHeaders,
-              compositeResponse.body
-            ).then((recordModificationResult) => [
-              subrequest[0],
-              recordModificationResult,
-            ]);
+            return subrequest[1]
+              .processResponse(
+                compositeResponse.httpStatusCode,
+                compositeResponse.httpHeaders,
+                compositeResponse.body
+              )
+              .then((recordModificationResult) => [
+                subrequest[0],
+                recordModificationResult,
+              ]);
           }
         )
       );

--- a/src/sdk/sub-request.ts
+++ b/src/sdk/sub-request.ts
@@ -9,6 +9,7 @@ import {
   RecordForCreate,
   RecordForUpdate,
   RecordModificationResult,
+  ReferenceId,
 } from "sf-fx-sdk-nodejs";
 
 export interface CompositeSubRequest<T> {
@@ -64,7 +65,7 @@ export class UpdateRecordSubRequest
   constructor(record: RecordForUpdate) {
     this.record = record;
 
-    this.body = { ...record.fields };
+    this.body = expandReferenceIds(record.fields);
     delete this.body.type;
     delete this.body.id;
   }
@@ -96,7 +97,7 @@ export class CreateRecordSubRequest
   constructor(record: RecordForCreate) {
     this.record = record;
 
-    this.body = { ...record.fields };
+    this.body = expandReferenceIds(record.fields);
     delete this.body.type;
   }
 
@@ -125,4 +126,20 @@ function parseErrorResponse(errorResponse: [any]): Error {
       })
       .join("\n")
   );
+}
+
+function expandReferenceIds(fields: { [key: string]: unknown }): {
+  [key: string]: unknown;
+} {
+  const newFields = { ...fields };
+  for (const [k, v] of Object.entries(newFields)) {
+    if (isReferenceId(v)) {
+      newFields[k] = v.toApiString();
+    }
+  }
+  return newFields;
+}
+
+function isReferenceId(val: any): val is ReferenceId {
+  return (val as ReferenceId).toApiString !== undefined;
 }

--- a/src/sdk/unit-of-work.ts
+++ b/src/sdk/unit-of-work.ts
@@ -19,6 +19,19 @@ import {
   UpdateRecordSubRequest,
 } from "./sub-request.js";
 
+export class ReferenceIdImpl implements ReferenceId {
+  readonly id: string;
+  constructor(id: string) {
+    this.id = id;
+  }
+  toString() {
+    return this.id;
+  }
+  toApiString() {
+    return `@{${this.id}.id}`;
+  }
+}
+
 export class UnitOfWorkImpl implements UnitOfWork {
   private readonly apiVersion: string;
   private readonly _subrequests: [
@@ -60,7 +73,7 @@ export class UnitOfWorkImpl implements UnitOfWork {
   }
 
   private generateReferenceId() {
-    const referenceId = "referenceId" + this.referenceIdCounter;
+    const referenceId = new ReferenceIdImpl("referenceId" + this.referenceIdCounter);
     this.referenceIdCounter = this.referenceIdCounter + 1;
 
     return referenceId;

--- a/src/sdk/unit-of-work.ts
+++ b/src/sdk/unit-of-work.ts
@@ -73,7 +73,9 @@ export class UnitOfWorkImpl implements UnitOfWork {
   }
 
   private generateReferenceId() {
-    const referenceId = new ReferenceIdImpl("referenceId" + this.referenceIdCounter);
+    const referenceId = new ReferenceIdImpl(
+      "referenceId" + this.referenceIdCounter
+    );
     this.referenceIdCounter = this.referenceIdCounter + 1;
 
     return referenceId;

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -552,7 +552,7 @@ describe("DataApi Class", async () => {
             type: "Movie__c",
             fields: {
               Name: "Star Wars Episode I - A Phantom Menace",
-              Franchise__c: "@{referenceId0.id}",
+              Franchise__c: rId0.toApiString(),
             },
           });
 
@@ -560,7 +560,7 @@ describe("DataApi Class", async () => {
             type: "Movie__c",
             fields: {
               Name: "Star Wars Episode II - Attack Of The Clones",
-              Franchise__c: "@{referenceId0.id}",
+              Franchise__c: rId0.toApiString(),
             },
           });
 
@@ -568,7 +568,7 @@ describe("DataApi Class", async () => {
             type: "Movie__c",
             fields: {
               Name: "Star Wars Episode III - Revenge Of The Sith",
-              Franchise__c: "@{referenceId0.id}",
+              Franchise__c: rId0.toApiString(),
             },
           });
 

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -552,7 +552,7 @@ describe("DataApi Class", async () => {
             type: "Movie__c",
             fields: {
               Name: "Star Wars Episode I - A Phantom Menace",
-              Franchise__c: rId0.toApiString(),
+              Franchise__c: rId0,
             },
           });
 
@@ -560,7 +560,7 @@ describe("DataApi Class", async () => {
             type: "Movie__c",
             fields: {
               Name: "Star Wars Episode II - Attack Of The Clones",
-              Franchise__c: rId0.toApiString(),
+              Franchise__c: rId0,
             },
           });
 


### PR DESCRIPTION
Grants function developers the ability to build API requests with references to objects that have not yet been created, modified, or deleted, using the new `toApiString()` method.

Fixes #124
Depends on https://github.com/forcedotcom/sf-fx-sdk-nodejs/pull/98.

Example usage:
```js
const uow = context.org.dataApi.newUnitOfWork();

const accountId = uow.registerCreate({
  type: "Account",
  fields: {
    Name: "Josh"
  }
});
const contactId = uow.registerCreate({
  type: "Contact",
  fields: {
    FirstName: "Josh",
    // Some versions of the Salesforce API (v50.0 and below?) support `AccountId: "referenceId0"`
    // The `AccountId: "@{referenceId0.id}"` format has broader support, which is what `.toApiString()` provides.
    // We'll automatically expand any `ReferenceId` (such as `accountId` here) in the fields with `.toApiString()`.
    // That's equivalent to the more explicit way:`AccountId: accountId.toApiString()`.
    AccountId: accountId
 }
});

await context.org.dataApi.commitUnitOfWork(uow);
```