### PR TITLE
Omnibus update: release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /dist/
 docs/
 node_modules/
-sf-fx-runtime-nodejs-*.tgz
+*sf-fx-runtime-nodejs-*.tgz
 tsconfig.tsbuildinfo
 .idea
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.1] - 2021-09-07
 
-- Update package name to @heroku/sf-fx-runtime-nodejs
+- Update package name to @heroku/sf-fx-runtime-nodejs ([#139](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/139))
 
 ## [0.5.0] - 2021-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2021-09-07
+
+- Update package name to @heroku/sf-fx-runtime-nodejs
+
 ## [0.5.0] - 2021-09-07
 
 - Automatically expand ReferenceIDs with `.toApiString()` ([#133](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/133))

--- a/bin/invoke.js
+++ b/bin/invoke.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import index from "../src/index.js";
+import index from "../dist/index.js";
 
 // eslint-disable-next-line no-undef
 await index(process.argv);

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -6,7 +6,7 @@ aws_cli_profile=${2:-"sf-fx-ea"}
 
 # The package filename cannot be customized for npm pack.
 # We need to figure out the file it will write to on our own:
-name=$(jq -r .name package.json)
+name=$(jq -r '.name | gsub("@";"") | gsub("/";"-")' package.json)
 version=$(jq -r .version package.json)
 package_filename="${name}-${version}.tgz"
 
@@ -35,6 +35,9 @@ npm pack
 
 echo "Pushing packaged tarball to s3 bucket:"
 aws s3 cp "${package_filename}" "s3://${bucket_name}" --profile "${aws_cli_profile}"
+
+echo "Running npm publish..."
+npm publish
 
 echo "Creating git tag..."
 git tag "v${version}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "sf-fx-runtime-nodejs",
-  "version": "0.4.0",
+  "name": "@heroku/sf-fx-runtime-nodejs",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.0",
+      "name": "@heroku/sf-fx-runtime-nodejs",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "@salesforce/core": "^2.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sf-fx-runtime-nodejs",
+  "name": "@heroku/sf-fx-runtime-nodejs",
   "version": "0.5.0",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",


### PR DESCRIPTION
This is an omnibus update aimed at fixing a few things with the release process and the most recent release:

- `bin/invoke.js` was pointing to a `src/` file, so the binary package was not working in 0.5.0 (introduced in #118).
- This package is now published to https://www.npmjs.com/package/@heroku/sf-fx-runtime-nodejs, but the scoping was not reflected in the `package.json`
- Our publish script now also publishes to npm, since this is a public package.
- Our release scripting was based on the previous flat package name. The `npm pack` produced tarball had a different name than expected due to the scoped name change, so the s3 upload was not working correctly.
- Tagging a new release inline for expediency, 0.5.0 is broken.