### PR TITLE
Prepare release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2021-09-21
+
 - Convert package-lock.json to npm-shrinkwrap.json for deterministic dependencies ([#165](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/165))
 - Rename apexClassId -> apexId and apexClassFQN -> apexFQN to support Apex classes and triggers.
 - Introduce NodeJS clustering, manage workers via throng ([#157](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/157))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 2021-09-21
+## [0.6.0] - 2021-09-22
 
 - Convert package-lock.json to npm-shrinkwrap.json for deterministic dependencies ([#165](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/165))
 - Rename apexClassId -> apexId and apexClassFQN -> apexFQN to support Apex classes and triggers.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@heroku/sf-fx-runtime-nodejs",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "@salesforce/core": "^2.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {


### PR DESCRIPTION
Let's release the recent changes as v0.6.0:

- #165 
- #157 
- #152 

This will release the npm package. It won't affect customer builds until we bring this change into heroku/buildpacks-nodejs and heroku/pack-images, so there is no production impact.