### PR TITLE
Improve error handling when Core response is not JSON or not 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Error handling for when API response cannot be parsed as JSON ([#174](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/174))
+
 ## [0.9.1] - 2021-10-13
 
 - Bind debugger to --host ([#207](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/207))

--- a/mappings/query-unparseable-body.json
+++ b/mappings/query-unparseable-body.json
@@ -1,0 +1,39 @@
+{
+  "id": "b843b9c1-6491-4046-90d4-08d6f90cb738",
+  "name": "services_data_v510_query",
+  "request": {
+    "urlPath": "/services/data/v51.0/query",
+    "method": "GET",
+    "queryParameters": {
+      "q": {
+        "equalTo": "SELECT Name FROM VeggieVendor__c"
+      }
+    },
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system, system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color: #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is for use in illustrative examples in documents. You may use this\n    domain in literature without prior coordination or asking for permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n",
+    "headers": {
+      "Age": "63",
+      "Cache-Control": "max-age=604800",
+      "Content-Type": "text/html; charset=UTF-8",
+      "Date": "Thu, 15 Apr 2021 12:04:45 GMT",
+      "Expires": "Thu, 22 Apr 2021 12:04:45 GMT",
+      "Last-Modified": "Thu, 15 Apr 2021 12:03:42 GMT",
+      "Server": "ECS (oxr/8314)",
+      "Vary": "Accept-Encoding",
+      "X-Cache": "404-HIT"
+    }
+  },
+  "uuid": "b843b8c1-6492-4048-90d5-08d6f90cb739",
+  "persistent": true,
+  "insertionIndex": 7
+}

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -259,10 +259,11 @@ export class DataApiImpl implements DataApi {
 
   private validate_response(response, validator) {
     if (typeof response !== "object" || !validator(response)) {
-      throw new Error("Could not parse API response as JSON!");
+      throw new Error("Could not parse API response as JSON: " + response);
     }
   }
 
+  // jsforce sets response body into `message` instead of `content`, so the output would not be helpful
   private handle_bad_response(error) {
     if (
       error.constructor.name == "HttpApiError" &&

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -89,6 +89,9 @@ export class DataApiImpl implements DataApi {
       try {
         const response = await conn.query(soql);
         const records = response.records.map(createCaseInsensitiveRecord);
+        if (records instanceof String) {
+          throw new Error("Could not parse API response as JSON!");
+        };
         return {
           done: response.done,
           totalSize: response.totalSize,

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -98,7 +98,6 @@ export class DataApiImpl implements DataApi {
           nextRecordsUrl: response.nextRecordsUrl,
         };
       } catch (e) {
-        console.log(e);
         this.handle_bad_response(e);
       }
       return undefined;
@@ -235,7 +234,6 @@ export class DataApiImpl implements DataApi {
   }
 
   private handle_bad_response(error) {
-    console.log(error.errorCode);
     if (error.errorCode && error.errorCode.includes("ERROR_HTTP_")) {
       throw new Error("Unexpected response with status: " + error.errorCode);
     } else {

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -76,14 +76,19 @@ export class DataApiImpl implements DataApi {
     recordCreate: RecordForCreate
   ): Promise<RecordModificationResult> {
     return this.promisifyRequests(async (conn: Connection) => {
-      const response: any = await conn.insert(
-        recordCreate.type,
-        recordCreate.fields
-      );
-      this.validate_response(response, function (response) {
-        return typeof response.id != "undefined";
-      });
-      return { id: response.id };
+      try {
+        const response: any = await conn.insert(
+          recordCreate.type,
+          recordCreate.fields
+        );
+        this.validate_response(response, function (response) {
+          return typeof response.id != "undefined";
+        });
+        return { id: response.id };
+      } catch (e) {
+        this.handle_bad_response(e);
+      }
+      return undefined;
     });
   }
 
@@ -122,21 +127,26 @@ export class DataApiImpl implements DataApi {
     }
 
     return this.promisifyRequests(async (conn: Connection) => {
-      const response = await conn.queryMore(queryResult.nextRecordsUrl);
-      this.validate_response(response, function (response) {
-        return (
-          typeof response.records === "object" &&
-          typeof response.records.map === "function"
-        );
-      });
-      const records = response.records.map(createCaseInsensitiveRecord);
+      try {
+        const response = await conn.queryMore(queryResult.nextRecordsUrl);
+        this.validate_response(response, function (response) {
+          return (
+            typeof response.records === "object" &&
+            typeof response.records.map === "function"
+          );
+        });
+        const records = response.records.map(createCaseInsensitiveRecord);
 
-      return {
-        done: response.done,
-        totalSize: response.totalSize,
-        records,
-        nextRecordsUrl: response.nextRecordsUrl,
-      };
+        return {
+          done: response.done,
+          totalSize: response.totalSize,
+          records,
+          nextRecordsUrl: response.nextRecordsUrl,
+        };
+      } catch (e) {
+        this.handle_bad_response(e);
+      }
+      return undefined;
     });
   }
 
@@ -155,22 +165,31 @@ export class DataApiImpl implements DataApi {
         fields[targetKey] = value;
       });
 
-      const response: any = await conn.update(recordUpdate.type, fields);
-      this.validate_response(response, function (response) {
-        return typeof response.id != "undefined";
-      });
-      return { id: response.id };
+      try {
+        const response: any = await conn.update(recordUpdate.type, fields);
+        this.validate_response(response, function (response) {
+          return typeof response.id != "undefined";
+        });
+        return { id: response.id };
+      } catch (e) {
+        this.handle_bad_response(e);
+      }
+      return undefined;
     });
   }
 
   async delete(type: string, id: string): Promise<RecordModificationResult> {
     return this.promisifyRequests(async (conn: Connection) => {
-      const response: any = await conn.delete(type, id);
-      this.validate_response(response, function (response) {
-        return typeof response.id != "undefined";
-      });
-
-      return { id: response.id };
+      try {
+        const response: any = await conn.delete(type, id);
+        this.validate_response(response, function (response) {
+          return typeof response.id != "undefined";
+        });
+        return { id: response.id };
+      } catch (e) {
+        this.handle_bad_response(e);
+      }
+      return undefined;
     });
   }
 

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -86,9 +86,8 @@ export class DataApiImpl implements DataApi {
         });
         return { id: response.id };
       } catch (e) {
-        this.handle_bad_response(e);
+        return this.handle_bad_response(e);
       }
-      return undefined;
     });
   }
 
@@ -110,9 +109,8 @@ export class DataApiImpl implements DataApi {
           nextRecordsUrl: response.nextRecordsUrl,
         };
       } catch (e) {
-        this.handle_bad_response(e);
+        return this.handle_bad_response(e);
       }
-      return undefined;
     });
   }
 
@@ -144,9 +142,8 @@ export class DataApiImpl implements DataApi {
           nextRecordsUrl: response.nextRecordsUrl,
         };
       } catch (e) {
-        this.handle_bad_response(e);
+        return this.handle_bad_response(e);
       }
-      return undefined;
     });
   }
 
@@ -172,9 +169,8 @@ export class DataApiImpl implements DataApi {
         });
         return { id: response.id };
       } catch (e) {
-        this.handle_bad_response(e);
+        return this.handle_bad_response(e);
       }
-      return undefined;
     });
   }
 
@@ -187,9 +183,8 @@ export class DataApiImpl implements DataApi {
         });
         return { id: response.id };
       } catch (e) {
-        this.handle_bad_response(e);
+        return this.handle_bad_response(e);
       }
-      return undefined;
     });
   }
 

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -80,7 +80,9 @@ export class DataApiImpl implements DataApi {
         recordCreate.type,
         recordCreate.fields
       );
-      this.validate_response(response, function (response) { return (typeof response.id != "undefined");});
+      this.validate_response(response, function (response) {
+        return typeof response.id != "undefined";
+      });
       return { id: response.id };
     });
   }
@@ -89,7 +91,12 @@ export class DataApiImpl implements DataApi {
     return this.promisifyRequests(async (conn: Connection) => {
       try {
         const response = await conn.query(soql);
-        this.validate_response(response, function (response) { return (typeof response.records === "object" && typeof response.records.map === "function");});
+        this.validate_response(response, function (response) {
+          return (
+            typeof response.records === "object" &&
+            typeof response.records.map === "function"
+          );
+        });
         const records = response.records.map(createCaseInsensitiveRecord);
         return {
           done: response.done,
@@ -116,7 +123,12 @@ export class DataApiImpl implements DataApi {
 
     return this.promisifyRequests(async (conn: Connection) => {
       const response = await conn.queryMore(queryResult.nextRecordsUrl);
-      this.validate_response(response, function (response) { return (typeof response.records === "object" && typeof response.records.map === "function");});
+      this.validate_response(response, function (response) {
+        return (
+          typeof response.records === "object" &&
+          typeof response.records.map === "function"
+        );
+      });
       const records = response.records.map(createCaseInsensitiveRecord);
 
       return {
@@ -144,7 +156,9 @@ export class DataApiImpl implements DataApi {
       });
 
       const response: any = await conn.update(recordUpdate.type, fields);
-      this.validate_response(response, function (response) { return (typeof response.id != "undefined");});
+      this.validate_response(response, function (response) {
+        return typeof response.id != "undefined";
+      });
       return { id: response.id };
     });
   }
@@ -152,7 +166,9 @@ export class DataApiImpl implements DataApi {
   async delete(type: string, id: string): Promise<RecordModificationResult> {
     return this.promisifyRequests(async (conn: Connection) => {
       const response: any = await conn.delete(type, id);
-      this.validate_response(response, function (response) { return (typeof response.id != "undefined");});
+      this.validate_response(response, function (response) {
+        return typeof response.id != "undefined";
+      });
 
       return { id: response.id };
     });
@@ -228,13 +244,17 @@ export class DataApiImpl implements DataApi {
   }
 
   private validate_response(response, validator) {
-    if ((typeof response !== "object") || (!validator(response))) {
+    if (typeof response !== "object" || !validator(response)) {
       throw new Error("Could not parse API response as JSON!");
     }
   }
 
   private handle_bad_response(error) {
-    if (error.constructor.name == "HttpApiError" && error.errorCode && error.errorCode.startsWith("ERROR_HTTP_")) {
+    if (
+      error.constructor.name == "HttpApiError" &&
+      error.errorCode &&
+      error.errorCode.startsWith("ERROR_HTTP_")
+    ) {
       error.content = error.message;
       error.message = "Unexpected response with status: " + error.errorCode;
     }

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -271,11 +271,8 @@ describe("DataApi Class", async () => {
       });
     });
 
-    // TODO: W-9281117 - This test fails since the raised exception is the entire body
-    // of the API response rather than a graceful error message.
     describe("with an unexpected response", async () => {
       it("returns a malformed query error", async () => {
-        // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
         try {
           await dataApi.query("SELECT Name FROM FruitVendor__c");
           expect.fail("Promise should have been rejected!");

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -273,7 +273,7 @@ describe("DataApi Class", async () => {
 
     // TODO: W-9281117 - This test fails since the raised exception is the entire body
     // of the API response rather than a graceful error message.
-    describe.skip("with an unexpected response", async () => {
+    describe("with an unexpected response", async () => {
       it("returns a malformed query error", async () => {
         // Chai doesn't yet support promises natively, so we can't use .rejectedWith-like syntax.
         try {

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -277,7 +277,9 @@ describe("DataApi Class", async () => {
           await dataApi.query("SELECT Name FROM FruitVendor__c");
           expect.fail("Promise should have been rejected!");
         } catch (e) {
-          expect(e.message).match(/^Could not parse API response as JSON!/);
+          expect(e.message).equal(
+            "Unexpected response with status: ERROR_HTTP_404"
+          );
         }
       });
     });

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -290,7 +290,9 @@ describe("DataApi Class", async () => {
           await dataApi.query("SELECT Name FROM VeggieVendor__c");
           expect.fail("Promise should have been rejected!");
         } catch (e) {
-          expect(e.message).equal("Could not parse API response as JSON!");
+          expect(e.message).to.includes(
+            "Could not parse API response as JSON: "
+          );
         }
       });
     });

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -283,6 +283,17 @@ describe("DataApi Class", async () => {
         }
       });
     });
+
+    describe("with a unparseable json as body", async () => {
+      it("returns a malformed query error", async () => {
+        try {
+          await dataApi.query("SELECT Name FROM VeggieVendor__c");
+          expect.fail("Promise should have been rejected!");
+        } catch (e) {
+          expect(e.message).equal("Could not parse API response as JSON!");
+        }
+      });
+    });
   });
 
   describe("queryMore()", async () => {


### PR DESCRIPTION
The Node.js SDK doesn't gracefully handle the case where the server API response cannot be parsed as JSON. To fix this, the code now detects an ERROR_HTTP_404 error code and checks if the error message is json parseable before throwing a new error.

GUS-W-9281117