### PR TITLE
Update package.json for 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {


### PR DESCRIPTION
A continuation from https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/184. In that PR I manually updated the files instead of running `npm run bump 0.7.0` which revs the version in package.json. This commit addresses that oversight.

GUS-W-9944567