### PR TITLE
Update release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,14 @@ $ aws sts get-caller-identity --profile sf-fx-ea > /dev/null && echo $?
 0
 ```
 
-Then, run the following:
+Make sure you've got access to release the NPM package:
+
+```
+$ npm access ls-packages @heroku | grep sf-fx-runtime-nodejs
+  "@heroku/sf-fx-runtime-nodejs": "read-write"
+```
+
+You'll be asked for your NPM two-factor authentication code when releasing. To release, run:
 
 ```
 $ npm run release


### PR DESCRIPTION
I was surprised to see this output while releasing:

```
npm notice total files:   24
npm notice
This operation requires a one-time password.
Enter OTP:
```

I wanted to document that a OTP will be requested and that it's from NPM. While contextually the output right above the prompt is from NPM, it also has a `npm notice`. 

It was initially unclear if this prompt was coming from NPM or from the next step in the release script.