### PR TITLE
Bind the debugger to the provided host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bind debugger to --host ([#207](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/207))
+
 ## [0.9.0] - 2021-10-13
 
 - Reintroduce NodeJS clustering, worker management via throng ([#203](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/203))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,7 +88,7 @@ export default async function (
   const master = function () {
     if (debugPort) {
       const { execArgv } = process;
-      execArgv.push("--inspect");
+      execArgv.push(`--inspect=${args.host}`);
       cluster.setupMaster({
         execArgv,
         inspectPort: debugPort,

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -75,13 +75,15 @@ describe("cli.ts", async () => {
       "/some/path/to/cli-binary.js",
       "serve",
       "./fixtures/js-esm-template",
+      "-h",
+      "0.0.0.0",
       "-d",
       "8888",
     ];
     const startServerSpy = spy();
     await cli(args, loadUserFunctionFromDirectory, startServerSpy, fakeThrong);
     const { settings } = cluster;
-    expect(settings.execArgv).to.include("--inspect");
+    expect(settings.execArgv).to.include("--inspect=0.0.0.0");
     expect(settings.inspectPort).to.eq(8888);
   });
 


### PR DESCRIPTION
In #203, we started binding the provided `--debug-port` argument to 1 worker process. We did not specify a host, which means the debug host gets a default of `127.0.0.1`. However, `127.0.0.1` means "this container" in docker parlance, not "this machine". So, the debugger can't be bound to inspectors/debuggers outside of the container. 

This change lets us use the `--host` parameter to set the debugger host. This will allow folks using this CLI in a container to connect a host-side debugger with something like `sf-fx-runtime-nodejs serve /myapp --host 0.0.0.0 --debug-port 9229`.

GUS-W-10017672