### PR TITLE
Ensure a fresh, clean build when packaging/publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "lint": "eslint . --ext .ts --max-warnings 0 --report-unused-disable-directives --format codeframe",
     "wiremock": "wiremock --port 8080",
     "mocha": "mocha",
@@ -12,7 +12,7 @@
     "format": "npm run format:write && npm run format:check",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
-    "prepare": "npm run build",
+    "prepack": "tsc -b --clean && tsc -b --force",
     "bump": "node ./scripts/bump-version.js",
     "release": "./etc/publish.sh"
   },


### PR DESCRIPTION
In the past, we've seen outdated .js files get published with `npm publish`. That's because typescript isn't deleting old compiled files when the source .ts files were renamed. 

The `--clean` option is new and exclusive to the new-ish `--build / -b` version of `tsc` that supports incremental builds. When publishing, we'll now `--clean` (deleting old artifacts), then `--force` (rebuild all source files, ignoring incremental status).

This change ensures that we publish packages with fully accurate .js files. Because we're publishing fresh, accurate .js files, we no longer need to run `tsc` after this package is installed. Previously, `tsc` was running after package installation because that's normal for `prepare` scripts.