### PR TITLE
Update CI matrix: more node versions + windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,62 @@ orbs:
   node: circleci/node@4.7
   win: circleci/windows@2.2.0
 
+commands:
+  install-openjdk:
+    description: "A command to install the openjdk. See https://circleci.com/developer/orbs/orb/cloudesire/openjdk-install."
+    parameters:
+      version:
+        type: integer
+        default: 8
+      cache_version:
+        type: integer
+        default: 1
+    steps:
+      - run:
+          name: Workaround for running apt behind the scene
+          command: sudo killall -9 apt-get || true
+      - run:
+          name: Switch to US mirror for faster performances
+          command: sudo sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
+      - run:
+          name: Add openjdk-r PPA
+          command: |
+            sudo add-apt-repository ppa:openjdk-r/ppa
+            sudo apt-get update
+      - run:
+          name: Generate cache version
+          command: |
+            apt-cache policy openjdk-<< parameters.version >>-jdk | grep 'Candidate:' | cut -d' ' -f4 > .openjdk_version
+            cat .openjdk_version
+      - restore_cache:
+          keys:
+          - apt-cache-{{ checksum ".openjdk_version" }}-v<< parameters.cache_version >>
+      - run:
+          name: Create temp directory if restore cache didn't
+          command: mkdir -p /tmp/archives
+      - run:
+          name: Restore apt cache
+          command: sudo rsync -av /tmp/archives/ /var/cache/apt/archives/
+      - run:
+          name: Install openjdk-<< parameters.version >>-jdk
+          command: |
+            sudo apt-get install -y openjdk-<< parameters.version >>-jdk
+            sudo update-java-alternatives --set java-1.<< parameters.version >>.0-openjdk-amd64
+      - run:
+          name: Prepare to save apt cache
+          command: rsync -av /var/cache/apt/archives/*.deb /tmp/archives/
+      - save_cache:
+          key: apt-cache-{{ checksum ".openjdk_version" }}-v<< parameters.cache_version >>
+          paths:
+          - /tmp/archives
+
 jobs:
   node-17: &test
     docker:
       - image: node:17
     steps:
+      # openjdk required for testing with wiremock
+      - install-openjdk
       - checkout
       - node/install-packages
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ version: 2.1
 
 orbs:
   node: circleci/node@4.7
+  win: circleci/windows@2.2.0
 
 jobs:
-  check-and-build:
+  node-17: &test
     docker:
-      # We need the JDK in order to run Wiremock.
-      - image: cimg/openjdk:11.0-node
+      - image: node:17
     steps:
       - checkout
       - node/install-packages
@@ -23,6 +23,35 @@ jobs:
       - run:
           name: Run build
           command: npm run build
+    node-16:
+      <<: *test
+      docker:
+        - image: node:16
+    node-14:
+      <<: *test
+      docker:
+        - image: node:14
+    windows:
+          executor:
+      name: win/default
+      shell: powershell.exe
+    steps:
+      - checkout
+      - run: systeminfo
+      - run:
+          name: node info
+          shell: powershell.exe
+          command: |
+            node --version
+            npm --version
+      - run:
+          name: Install dependencies
+          shell: powershell.exe
+          command: npm ci
+      - run:
+          name: Run unit tests
+          shell: powershell.exe
+          command: npm run test
 
 workflows:
   check-and-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,8 @@ commands:
           command: |
             apt-get update
             sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
-            apt-get install -y software-properties-common
+            apt-get install -y --no-install-recommends software-properties-common apt-transport-https ca-certificates
+            apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys EB9B1D8886F44E2A
             add-apt-repository -y ppa:openjdk-r/ppa
             apt-get update -y
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ commands:
             apt-get update
             sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
             apt-get install -y software-properties-common
-            add-apt-repository ppa:openjdk-r/ppa
-            apt-get update
+            add-apt-repository -y ppa:openjdk-r/ppa
+            apt-get update -y
       - run:
           name: Generate cache version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,58 +6,20 @@ orbs:
   win: circleci/windows@2.2.0
 
 commands:
-  install-openjdk:
-    description: "A command to install the openjdk. See https://circleci.com/developer/orbs/orb/cloudesire/openjdk-install."
-    parameters:
-      version:
-        type: integer
-        default: 8
-      cache_version:
-        type: integer
-        default: 1
+  install-java:
     steps:
       - run:
-          name: Add openjdk-r PPA
+          name: Install default jre
           command: |
             apt-get update
-            sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
-            apt-get install -y --no-install-recommends software-properties-common apt-transport-https ca-certificates
-            apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys EB9B1D8886F44E2A
-            add-apt-repository -y ppa:openjdk-r/ppa
-            apt-get update -y
-      - run:
-          name: Generate cache version
-          command: |
-            apt-cache policy openjdk-<< parameters.version >>-jdk | grep 'Candidate:' | cut -d ' ' -f4 > .openjdk_version
-            cat .openjdk_version
-      - restore_cache:
-          keys:
-          - apt-cache-{{ checksum ".openjdk_version" }}-v<< parameters.cache_version >>
-      - run:
-          name: Restore apt cache
-          command: |
-            mkdir -p /tmp/archives
-            rsync -av /tmp/archives/ /var/cache/apt/archives/
-      - run:
-          name: Install openjdk-<< parameters.version >>-jdk
-          command: |
-            apt-get install -y openjdk-<< parameters.version >>-jdk
-            update-java-alternatives --set java-1.<< parameters.version >>.0-openjdk-amd64
-      - run:
-          name: Prepare to save apt cache
-          command: rsync -av /var/cache/apt/archives/*.deb /tmp/archives/
-      - save_cache:
-          key: apt-cache-{{ checksum ".openjdk_version" }}-v<< parameters.cache_version >>
-          paths:
-          - /tmp/archives
-
+            apt-get install -y --no-install-recommends default-jre
 jobs:
   node-17: &test
     docker:
       - image: node:17
     steps:
-      # openjdk required for testing with wiremock
-      - install-openjdk
+      # java required for testing with wiremock
+      - install-java
       - checkout
       - node/install-packages
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 
 orbs:
@@ -23,37 +24,40 @@ jobs:
       - run:
           name: Run build
           command: npm run build
-    node-16:
-      <<: *test
-      docker:
-        - image: node:16
-    node-14:
-      <<: *test
-      docker:
-        - image: node:14
-    windows:
-          executor:
+  node-16:
+    <<: *test
+    docker:
+      - image: node:16
+  node-14:
+    <<: *test
+    docker:
+      - image: node:14
+  windows:
+    executor:
       name: win/default
       shell: powershell.exe
     steps:
       - checkout
       - run: systeminfo
-      - run:
-          name: node info
-          shell: powershell.exe
-          command: |
-            node --version
-            npm --version
-      - run:
-          name: Install dependencies
-          shell: powershell.exe
-          command: npm ci
-      - run:
-          name: Run unit tests
-          shell: powershell.exe
-          command: npm run test
+        - run:
+            name: node info
+            shell: powershell.exe
+            command: |
+              node --version
+              npm --version
+        - run:
+            name: Install dependencies
+            shell: powershell.exe
+            command: npm ci
+        - run:
+            name: Run unit tests
+            shell: powershell.exe
+            command: npm run test
 
 workflows:
   check-and-build:
     jobs:
-      - check-and-build
+      - node-17
+      - node-16
+      - node-14
+      - windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
       - run:
           name: Add openjdk-r PPA
           command: |
-            killall -9 apt-get || true
+            apt-get update
             sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
             apt-get install -y software-properties-common
             add-apt-repository ppa:openjdk-r/ppa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,20 +39,20 @@ jobs:
     steps:
       - checkout
       - run: systeminfo
-        - run:
-            name: node info
-            shell: powershell.exe
-            command: |
-              node --version
-              npm --version
-        - run:
-            name: Install dependencies
-            shell: powershell.exe
-            command: npm ci
-        - run:
-            name: Run unit tests
-            shell: powershell.exe
-            command: npm run test
+      - run:
+          name: node info
+          shell: powershell.exe
+          command: |
+            node --version
+            npm --version
+      - run:
+          name: Install dependencies
+          shell: powershell.exe
+          command: npm ci
+      - run:
+          name: Run unit tests
+          shell: powershell.exe
+          command: npm run test
 
 workflows:
   check-and-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,30 +17,26 @@ commands:
         default: 1
     steps:
       - run:
-          name: Workaround for running apt behind the scene
-          command: killall -9 apt-get || true
-      - run:
-          name: Switch to US mirror for faster performances
-          command: sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
-      - run:
           name: Add openjdk-r PPA
           command: |
+            killall -9 apt-get || true
+            sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
+            apt-get install -y software-properties-common
             add-apt-repository ppa:openjdk-r/ppa
             apt-get update
       - run:
           name: Generate cache version
           command: |
-            apt-cache policy openjdk-<< parameters.version >>-jdk | grep 'Candidate:' | cut -d' ' -f4 > .openjdk_version
+            apt-cache policy openjdk-<< parameters.version >>-jdk | grep 'Candidate:' | cut -d ' ' -f4 > .openjdk_version
             cat .openjdk_version
       - restore_cache:
           keys:
           - apt-cache-{{ checksum ".openjdk_version" }}-v<< parameters.cache_version >>
       - run:
-          name: Create temp directory if restore cache didn't
-          command: mkdir -p /tmp/archives
-      - run:
           name: Restore apt cache
-          command: rsync -av /tmp/archives/ /var/cache/apt/archives/
+          command: |
+            mkdir -p /tmp/archives
+            rsync -av /tmp/archives/ /var/cache/apt/archives/
       - run:
           name: Install openjdk-<< parameters.version >>-jdk
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,15 @@ commands:
     steps:
       - run:
           name: Workaround for running apt behind the scene
-          command: sudo killall -9 apt-get || true
+          command: killall -9 apt-get || true
       - run:
           name: Switch to US mirror for faster performances
-          command: sudo sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
+          command: sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
       - run:
           name: Add openjdk-r PPA
           command: |
-            sudo add-apt-repository ppa:openjdk-r/ppa
-            sudo apt-get update
+            add-apt-repository ppa:openjdk-r/ppa
+            apt-get update
       - run:
           name: Generate cache version
           command: |
@@ -40,12 +40,12 @@ commands:
           command: mkdir -p /tmp/archives
       - run:
           name: Restore apt cache
-          command: sudo rsync -av /tmp/archives/ /var/cache/apt/archives/
+          command: rsync -av /tmp/archives/ /var/cache/apt/archives/
       - run:
           name: Install openjdk-<< parameters.version >>-jdk
           command: |
-            sudo apt-get install -y openjdk-<< parameters.version >>-jdk
-            sudo update-java-alternatives --set java-1.<< parameters.version >>.0-openjdk-amd64
+            apt-get install -y openjdk-<< parameters.version >>-jdk
+            update-java-alternatives --set java-1.<< parameters.version >>.0-openjdk-amd64
       - run:
           name: Prepare to save apt cache
           command: rsync -av /var/cache/apt/archives/*.deb /tmp/archives/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix bug when attempting to load functions on windows with a `c:` prefix ([#262](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/262))
 - Error handling for when API response cannot be parsed as JSON ([#174](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/174))
 
 ## [0.9.1] - 2021-10-13

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint . --ext .ts --max-warnings 0 --report-unused-disable-directives --format codeframe",
     "wiremock": "wiremock --port 8080",
     "mocha": "mocha",
-    "test": "concurrently -k -s first 'npm run wiremock' 'npm run mocha'",
+    "test": "concurrently -k -s first \"npm run wiremock\" \"npm run mocha\"",
     "format": "npm run format:write && npm run format:check",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",

--- a/src/user-function.ts
+++ b/src/user-function.ts
@@ -10,7 +10,9 @@ import * as path from "path";
 import { pathToFileURL } from "url";
 import { SalesforceFunction } from "sf-fx-sdk-nodejs";
 
-export async function loadDefaultExport(fileUrl: string): Promise<SalesforceFunction<unknown, unknown>> {
+export async function loadDefaultExport(
+  fileUrl: string
+): Promise<SalesforceFunction<unknown, unknown>> {
   // Attempt to load the default export for a given file.
   let fExports: any;
 


### PR DESCRIPTION
This change adds a matrix for CI testing. We now test against supported versions of node on linux, plus the latest stable node on windows.

This uncovered a bug in windows where the ESM module loader would fail with a path like `c:\something`. I've fixed that in this PR, where we convert a plain path to a `file://` url. 

GUS-W-10379120.