### PR TITLE
Adjust data-api error messages to be more informative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improved DataAPI error messaging ([#294](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/294))
+
 ## [0.10.0] - 2022-02-10
 
 - Salesforce Rest API version may be specified in a function's project.toml ([#276](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/276))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2022-02-23
+
 - Improved DataAPI error messaging ([#294](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/294))
 
 ## [0.10.0] - 2022-02-10

--- a/mappings/query-resource-not-found.json
+++ b/mappings/query-resource-not-found.json
@@ -1,0 +1,43 @@
+{
+  "id": "9485e6ef-67d6-409e-9d57-74cd2b547a3e",
+  "name": "services_data_v510_query",
+  "request": {
+    "urlPath": "/services/data/v51.0/query",
+    "method": "GET",
+    "queryParameters": {
+      "q": {
+        "equalTo": "SELECT VersionData FROM ContentVersion"
+      }
+    },
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer 00DB0000000UIn2!AQMAQKXBvR03lDdfMiD6Pdpo_wiMs6LGp6dVkrwOuqiiTEmwdPb8MvSZwdPLe009qHlwjxIVa4gY.JSAd0mfgRRz22vS"
+      },
+      "Sforce-Call-Options": {
+        "matches": "client=sf-fx-runtime-nodejs-sdk-impl-v\\d+:\\d+\\.\\d+\\.\\d+(-[a-zA-Z]+)*"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "[{\"errorCode\":\"NOT_FOUND\",\"message\":\"The requested resource does not exist\"}]",
+    "headers": {
+      "Date": "Tue, 13 Apr 2021 12:54:25 GMT",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Set-Cookie": [
+        "BrowserId=YCFhGpxXEeusdp17qoCg0Q; domain=.salesforce.com; path=/; expires=Wed, 13-Apr-2022 12:54:25 GMT; Max-Age=31536000",
+        "BrowserId_sec=YCFhGpxXEeusdp17qoCg0Q; domain=.salesforce.com; path=/; expires=Wed, 13-Apr-2022 12:54:25 GMT; Max-Age=31536000; secure; SameSite=None"
+      ],
+      "Sforce-Limit-Info": "api-usage=24/100000",
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "9485e6ef-67d6-409e-9d57-74cd2b547a3e",
+  "persistent": true,
+  "insertionIndex": 1
+}
+

--- a/mappings/query-resource-not-found.json
+++ b/mappings/query-resource-not-found.json
@@ -40,4 +40,3 @@
   "persistent": true,
   "insertionIndex": 1
 }
-

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@heroku/sf-fx-runtime-nodejs",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "ISC",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -152,7 +152,7 @@ export class DataApiImpl implements DataApi {
 
       try {
         const response: any = await conn.update(recordUpdate.type, fields);
-        this.validate_record_response(response)
+        this.validate_record_response(response);
         return { id: response.id };
       } catch (e) {
         return this.handle_bad_response(e);
@@ -164,7 +164,7 @@ export class DataApiImpl implements DataApi {
     return this.promisifyRequests(async (conn: Connection) => {
       try {
         const response: any = await conn.delete(type, id);
-        this.validate_record_response(response)
+        this.validate_record_response(response);
         return { id: response.id };
       } catch (e) {
         return this.handle_bad_response(e);
@@ -243,21 +243,30 @@ export class DataApiImpl implements DataApi {
 
   private validate_response(response: any) {
     if (typeof response !== "object") {
-      throw new Error("Could not parse API response as JSON: " + JSON.stringify(response));
+      throw new Error(
+        "Could not parse API response as JSON: " + JSON.stringify(response)
+      );
     }
   }
 
   private validate_record_response(response: any) {
     this.validate_response(response);
     if (typeof response.id === "undefined") {
-      throw new Error("Could not read API response `id`: " + JSON.stringify(response));
+      throw new Error(
+        "Could not read API response `id`: " + JSON.stringify(response)
+      );
     }
   }
 
   private validate_records_response(response: any) {
     this.validate_response(response);
-    if (typeof response.records !== "object" || typeof response.records.map !== "function") {
-      throw new Error("Could not read API response `records`: " + JSON.stringify(response));
+    if (
+      typeof response.records !== "object" ||
+      typeof response.records.map !== "function"
+    ) {
+      throw new Error(
+        "Could not read API response `records`: " + JSON.stringify(response)
+      );
     }
   }
 

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -296,6 +296,19 @@ describe("DataApi Class", async () => {
         }
       });
     });
+
+    describe("with 200: not found", async () => {
+      it("returns a missing records error", async () => {
+        try {
+          await dataApi.query("SELECT VersionData FROM ContentVersion");
+          expect.fail("Promise should have been rejected!");
+        } catch (e) {
+          expect(e.message).to.includes(
+            "Could not read API response `records`:"
+          );
+        }
+      });
+    });
   });
 
   describe("queryMore()", async () => {


### PR DESCRIPTION
There are internal reports of queries like `context.org.dataApi.query('SELECT VersionData, FileExtension FROM ContentVersion LIMIT 1');` failing with error messages like `Could not parse API response as JSON`. The actual API response looks like `[{"errorCode":"NOT_FOUND","message":"The requested resource does not exist"}]`, which **is** valid JSON. The actual problem is that `records` is not included in the response.

This PR makes two changes to make debugging a little smoother:

1) Includes the JSON stringified payload in the error message rather than the JS string representation of the response (which might be `[object Object]` or ``).
2) Is more specific about what is missing from the response (`id` in the case of singular object, `records` in the case of an expected set of objects).

Note that this particular error scenario (a successful/200 response, with an error message, but no `records`) arises from incorrect permissions regarding `VersionData`. This may be fixed in the upstream API in a future release.

GUS-W-10728741