### PR TITLE
Fix and verify worker processes are properly shutdown

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -7,7 +7,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-// this script is meant to be invoked from shutdown.test.ts
+// this script is meant to be invoked like this:
+// > node --loader ts-node/esm bin/dev.js
 import cli from "../src/cli.js";
 // eslint-disable-next-line no-undef
 await cli(process.argv);

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// this script is meant to be invoked from shutdown.test.ts
+import cli from "../src/cli.js";
+// eslint-disable-next-line no-undef
+await cli(process.argv);

--- a/fixtures/long-running-function/index.js
+++ b/fixtures/long-running-function/index.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const DEFAULT_TIMEOUT = 10 * 1000; // 10s
+
+export default async function (event, context, logger) {
+  // eslint-disable-next-line no-undef
+  const timeoutFromEnv = process.env.LONG_RUNNING_PROCESS_TIMEOUT;
+  const timeout = timeoutFromEnv
+    ? parseInt(timeoutFromEnv, 10)
+    : DEFAULT_TIMEOUT;
+  logger.info(
+    `Simulating a long running process that takes ${timeout}ms to complete`
+  );
+  // eslint-disable-next-line no-undef
+  await new Promise((resolve) => setTimeout(resolve, timeout));
+  logger.info("Done task");
+  return [{ complete: true }];
+}

--- a/fixtures/long-running-function/package.json
+++ b/fixtures/long-running-function/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "long-running-function",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "index.js",
+  "engines": {
+    "node": "^14.0"
+  }
+}

--- a/fixtures/long-running-function/project.toml
+++ b/fixtures/long-running-function/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "long-running"
+description = "A Salesforce Function"
+type = "function"
+salesforce-api-version = "54.0"

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -92,11 +92,12 @@ describe("cli shutdown routine", function () {
     );
 
     const closedInvokerProcess = await spawnedInvoker.processClosed;
-    expect(closedInvokerProcess.code).to.equal(0);
     if (expectForcedShutdown) {
       expect(closedInvokerProcess.output).to.include("Empty reply from server");
+      expect(closedInvokerProcess.code).to.not.equal(0);
     } else {
       expect(closedInvokerProcess.output).to.include('[{"complete":true}]');
+      expect(closedInvokerProcess.code).to.equal(0);
     }
   }
 
@@ -142,7 +143,7 @@ function run(options: {
 }): Promise<ProcessSpawnedResult> {
   const node = process.argv[0];
 
-  const cliScript = path.resolve(__dirname, "..", "bin", "test.js");
+  const cliScript = path.resolve(__dirname, "..", "bin", "dev.js");
 
   const args = [
     "--loader",

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ChildProcess, spawn, execSync } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+import { expect } from "chai";
+
+type ProcessSpawnedResult = {
+  childProcess: ChildProcess;
+  processClosed: Promise<ProcessClosedResult>;
+};
+
+type ProcessClosedResult = {
+  output: string;
+  code: number;
+};
+
+type TestPids = {
+  primary: number | undefined;
+  workers: number[];
+  invoker: number | undefined;
+};
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+const PORT = 3000;
+const ONE_SECOND = 1000;
+const SECONDS = ONE_SECOND;
+const GRACE_PERIOD = 1000;
+
+describe("cli shutdown routine", function () {
+  this.timeout(30 * SECONDS);
+
+  let spawnedFunction: ProcessSpawnedResult;
+  let spawnedInvoker: ProcessSpawnedResult;
+  let pids: TestPids;
+
+  beforeEach(() => {
+    pids = {
+      primary: undefined,
+      workers: [],
+      invoker: undefined,
+    };
+  });
+
+  afterEach(() => {
+    if (pids.primary && isAlive(pids.primary)) {
+      process.kill(pids.primary, "SIGTERM");
+    }
+    pids.workers.forEach((pid) => {
+      if (isAlive(pid)) {
+        process.kill(pid, "SIGTERM");
+      }
+    });
+    if (pids.invoker && isAlive(pids.invoker)) {
+      process.kill(pids.invoker, "SIGTERM");
+    }
+  });
+
+  it("should exit gracefully", async function () {
+    await startAndInvokeFunctionThenShutdown({
+      timeToCleanlyShutdown: Math.floor(GRACE_PERIOD / 2),
+    });
+  });
+
+  it("should exit forcefully if the function has not completed before the grace period is reached", async function () {
+    await startAndInvokeFunctionThenShutdown({
+      timeToCleanlyShutdown: GRACE_PERIOD * 2,
+    });
+  });
+
+  async function startAndInvokeFunctionThenShutdown(options: {
+    timeToCleanlyShutdown: number;
+  }) {
+    const grace = GRACE_PERIOD;
+    const timeToCleanlyShutdown = options.timeToCleanlyShutdown;
+    const expectForcedShutdown = grace < timeToCleanlyShutdown;
+
+    await startFunction({ timeToCleanlyShutdown });
+    await invokeFunction();
+    await killFunctionProcess("SIGINT");
+
+    const closedFunctionProcess = await spawnedFunction.processClosed;
+    expect(closedFunctionProcess.code).to.equal(0);
+    expect(closedFunctionProcess.output).to.include(
+      "function worker exiting; received SIGINT"
+    );
+
+    const closedInvokerProcess = await spawnedInvoker.processClosed;
+    expect(closedInvokerProcess.code).to.equal(0);
+    if (expectForcedShutdown) {
+      expect(closedInvokerProcess.output).to.include("Empty reply from server");
+    } else {
+      expect(closedInvokerProcess.output).to.include('[{"complete":true}]');
+    }
+  }
+
+  function startFunction(options: { timeToCleanlyShutdown: number }) {
+    const port = PORT;
+    const grace = GRACE_PERIOD;
+    const functionProject = fixture("long-running-function");
+    const longRunningProcessTimeout = options.timeToCleanlyShutdown;
+    return run({
+      port,
+      grace,
+      functionProject,
+      longRunningProcessTimeout,
+    }).then((result) => {
+      spawnedFunction = result;
+      pids.primary = result.childProcess.pid;
+      pids.workers = getChildProcessIds(pids.primary);
+    });
+  }
+
+  function invokeFunction() {
+    const port = PORT;
+    const payload = {};
+    return invoke({ port, payload }).then((result) => {
+      spawnedInvoker = result;
+      pids.invoker = result.childProcess.pid;
+    });
+  }
+
+  function killFunctionProcess(signal: NodeJS.Signals) {
+    spawnedFunction.childProcess.kill(signal);
+    return new Promise((resolve) => {
+      setTimeout(resolve, GRACE_PERIOD + ONE_SECOND);
+    });
+  }
+});
+
+function run(options: {
+  functionProject: string;
+  port: number;
+  longRunningProcessTimeout: number;
+  grace: number;
+}): Promise<ProcessSpawnedResult> {
+  const node = process.argv[0];
+
+  const cliScript = path.resolve(__dirname, "..", "bin", "test.js");
+
+  const args = [
+    "--loader",
+    "ts-node/esm",
+    cliScript,
+    "serve",
+    options.functionProject,
+    "-h",
+    "localhost",
+    "-p",
+    `${options.port}`,
+    "-w",
+    "1",
+    "-g",
+    `${options.grace}`,
+  ];
+
+  const childProcess = spawn(node, args, {
+    detached: true,
+    cwd: path.resolve(__dirname, ".."),
+    env: {
+      ...process.env,
+      LONG_RUNNING_PROCESS_TIMEOUT: `${options.longRunningProcessTimeout}`,
+    },
+  });
+
+  let output = "";
+  return new Promise((resolve) => {
+    const processClosed = new Promise<ProcessClosedResult>((resolve) => {
+      childProcess.on("close", (code) => {
+        resolve({ output, code });
+      });
+    });
+
+    childProcess.stdout.on("data", (data) => {
+      process.stdout.write(`[function] ${data}`);
+      output += data;
+      if (output.includes("started function worker")) {
+        resolve({ childProcess, processClosed });
+      }
+    });
+  });
+}
+
+function invoke(options: {
+  port: number;
+  payload: Record<string, unknown>;
+}): Promise<ProcessSpawnedResult> {
+  const invoker = path.resolve(__dirname, "..", "invoke.sh");
+
+  const childProcess = spawn(
+    invoker,
+    [`http://localhost:${options.port}`, JSON.stringify(options.payload)],
+    { detached: true }
+  );
+
+  let output = "";
+  return new Promise((resolve) => {
+    const processClosed = new Promise<ProcessClosedResult>((resolve) => {
+      childProcess.on("close", (code) => {
+        resolve({ output, code });
+      });
+    });
+
+    const onDataHandler = (data) => {
+      process.stdout.write(`[invoker] ${data}`);
+      output += data;
+      if (output.includes("upload completely sent off")) {
+        resolve({ childProcess, processClosed });
+      }
+    };
+
+    childProcess.stderr.on("data", onDataHandler);
+    childProcess.stdout.on("data", onDataHandler);
+  });
+}
+
+function getChildProcessIds(parentPID: number): number[] {
+  return execSync(`pgrep -P ${parentPID}`)
+    .toString("utf8")
+    .split("\n")
+    .filter((s) => s)
+    .map((line) => parseInt(line.trim(), 10));
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    execSync(`ps -p ${pid}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fixture(name) {
+  return path.resolve(__dirname, "..", "fixtures", name);
+}


### PR DESCRIPTION
While implementing changes related to [heroku/sf-functions-core#45](https://github.com/heroku/sf-functions-core/pull/45) I noticed that worker processes could become orphaned when the primary process is forcefully killed.

The [`throng`](https://github.com/hunterloftis/throng) makes reference to this potential behavior [here](https://github.com/hunterloftis/throng/blob/5dc2ac054d1cedc94188f3a8372914368ebf9cce/lib/throng.js#L68-L77).  The implication of this is that worker processes need to properly implement their own graceful/forced shutdown routines.

This PR uses the same `grace` period from the primary process to configure each worker process.  The worker will wait for any outstanding http requests to finish before cleanly shutting down.  If the worker cannot cleanly shutdown before exceeding the `grace` period then the worker will then be forced to shut down.

[GUS-W-10819415](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000sOC4iYAG/view)