### PR TITLE
Fix and verify worker processes are properly shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2022-04-01
+
+- Added shutdown routine for worker processes ([#305](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/305))
+
 ## [0.11.0] - 2022-02-23
 
 - Improved DataAPI error messaging ([#294](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/294))

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// this script is meant to be invoked like this:
+// > node --loader ts-node/esm bin/dev.js
+import cli from "../src/cli.js";
+// eslint-disable-next-line no-undef
+await cli(process.argv);

--- a/fixtures/long-running-function/index.js
+++ b/fixtures/long-running-function/index.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const DEFAULT_TIMEOUT = 10 * 1000; // 10s
+
+export default async function (event, context, logger) {
+  // eslint-disable-next-line no-undef
+  const timeoutFromEnv = process.env.LONG_RUNNING_PROCESS_TIMEOUT;
+  const timeout = timeoutFromEnv
+    ? parseInt(timeoutFromEnv, 10)
+    : DEFAULT_TIMEOUT;
+  logger.info(
+    `Simulating a long running process that takes ${timeout}ms to complete`
+  );
+  // eslint-disable-next-line no-undef
+  await new Promise((resolve) => setTimeout(resolve, timeout));
+  logger.info("Done task");
+  return [{ complete: true }];
+}

--- a/fixtures/long-running-function/package.json
+++ b/fixtures/long-running-function/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "long-running-function",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "index.js",
+  "engines": {
+    "node": "^14.0"
+  }
+}

--- a/fixtures/long-running-function/project.toml
+++ b/fixtures/long-running-function/project.toml
@@ -1,0 +1,9 @@
+[_]
+schema-version = "0.2"
+
+[com.salesforce]
+schema-version = "0.2"
+id = "long-running"
+description = "A Salesforce Function"
+type = "function"
+salesforce-api-version = "54.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,8 +11,8 @@ import { hideBin } from "yargs/helpers";
 import throng from "throng";
 import { SalesforceFunction } from "sf-fx-sdk-nodejs";
 import { loadUserFunctionFromDirectory } from "./user-function.js";
-import { SalesforceConfig, readSalesforceConfig } from "./salesforce-config.js";
-import startServer from "./server.js";
+import { readSalesforceConfig } from "./salesforce-config.js";
+import startServer, { StartServerOptions } from "./server.js";
 import logger from "./logger.js";
 import * as path from "path";
 
@@ -52,6 +52,13 @@ export function parseArgs(params: Array<string>): any {
             description:
               "The number of Node.js cluster workers the invoker should use",
             default: 1,
+          })
+          .option("grace", {
+            alias: "g",
+            type: "number",
+            description:
+              "How long to wait for graceful shutdown before exiting forcefully",
+            default: 15 * 1000,
           });
       }
     )
@@ -65,14 +72,7 @@ export default async function (
   loadUserFunction: (
     p: string
   ) => Promise<SalesforceFunction<any, any>> = loadUserFunctionFromDirectory,
-  server: (
-    h: string,
-    p: number,
-    f: SalesforceFunction<any, any>,
-    c: SalesforceConfig,
-    w: number,
-    d: () => void
-  ) => Promise<void> = startServer,
+  server: (options: StartServerOptions) => Promise<void> = startServer,
   manager: (...p: Array<Record<string, unknown>>) => Promise<void> = throng
 ): Promise<void> {
   const args = parseArgs(params);
@@ -90,7 +90,10 @@ export default async function (
     path.join(projectPath, "project.toml")
   );
 
-  const { debugPort } = args;
+  const { debugPort, host, port, grace } = args;
+  const signals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
+  const count = debugPort ? 1 : args.workers;
+
   const master = function () {
     if (debugPort) {
       const { execArgv } = process;
@@ -106,16 +109,23 @@ export default async function (
     id: number,
     disconnect: () => void
   ): Promise<void> {
-    return await server(
-      args.host,
-      args.port,
+    return await server({
+      host,
+      port,
       userFunction,
       salesforceConfig,
       id,
-      disconnect
-    );
+      disconnect,
+      grace,
+      signals,
+    });
   };
 
-  const count = debugPort ? 1 : args.workers;
-  return await manager({ master, worker, count });
+  return await manager({
+    master,
+    worker,
+    count,
+    grace,
+    signals,
+  });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import * as fastify from "fastify";
 import { FastifyReply, FastifyInstance } from "fastify";
 import { LoggerImpl } from "./user-function-logger.js";
 import logger from "./logger.js";
+import { Logger } from "@salesforce/core";
 import {
   parseCloudEvent,
   SalesforceFunctionsCloudEvent,
@@ -135,31 +136,83 @@ export function buildServer(
   return server;
 }
 
+export type StartServerOptions = {
+  host: string;
+  port: number;
+  userFunction: SalesforceFunction<any, any>;
+  salesforceConfig: SalesforceConfig;
+  id: number;
+  disconnect: () => void;
+  grace: number;
+  signals: NodeJS.Signals[];
+};
+
 export default async function startServer(
-  host: string,
-  port: number,
-  userFunction: SalesforceFunction<any, any>,
-  salesforceConfig: SalesforceConfig,
-  workerId = 0,
-  shutdown: (e?: number) => void = process.exit
+  options: StartServerOptions
 ): Promise<void> {
-  logger.addField("worker", workerId);
+  const {
+    id,
+    host,
+    port,
+    userFunction,
+    salesforceConfig,
+    disconnect,
+    signals,
+    grace,
+  } = options;
+
+  logger.addField("worker", id);
+
   const server = buildServer(userFunction, salesforceConfig);
-  process.on("SIGTERM", () => {
-    logger.info(`function worker exiting; received SIGTERM`);
-    server.close(shutdown);
-  });
-  process.on("SIGINT", () => {
-    logger.info(`function worker exiting; received SIGINT`);
-    server.close(shutdown);
-  });
+  registerShutdownHooks({ server, disconnect, grace, signals, logger, host });
+
   try {
     await server.listen(port, host);
-    logger.info(`started function worker ${workerId}`);
+    logger.info(`started function worker ${id}`);
   } catch (err) {
-    logger.error(`error starting function worker ${workerId}: ${err}`);
-    shutdown(1);
+    logger.error(`error starting function worker ${id}: ${err}`);
+    disconnect();
   }
+}
+
+type RegisterShutdownHooksOptions = Pick<
+  StartServerOptions,
+  "disconnect" | "grace" | "signals"
+> & {
+  server: FastifyInstance;
+  logger: Logger;
+  host: string;
+};
+
+function registerShutdownHooks(options: RegisterShutdownHooksOptions): void {
+  const { server, disconnect, grace, signals, host } = options;
+
+  const shutdownGracefully = () => {
+    server.close(() => {
+      disconnect();
+    });
+  };
+
+  const forceShutdown = () => {
+    disconnect();
+    process.exit();
+  };
+
+  const handleShutdownSignal = (signal) => {
+    logger.info(`function worker exiting; received ${signal}`);
+    maybeStopLogging(logger, host);
+    shutdownGracefully();
+    setTimeout(forceShutdown, grace).unref();
+  };
+
+  let alreadyShuttingDown = false;
+  signals.forEach((signal) => {
+    process.on(signal, () => {
+      if (alreadyShuttingDown) return; // because we don't need to run the shutdown routine twice :)
+      alreadyShuttingDown = true;
+      handleShutdownSignal(signal);
+    });
+  });
 }
 
 function makeResponse(
@@ -193,3 +246,24 @@ const emptyExtraInfo = {
   isFunctionError: false,
   stack: "",
 };
+
+/**
+ * Removes `stdout` from the list of log streams to prevent any grandchild[^1] process from writing output to the
+ * console after the master process has exited.
+ * [^1]: sf - the Salesforce CLI spins up its local run environment via npx
+ *       └── primary - the primary runtime script executed by npx
+ *           └── worker - one or more forked processes from the primary process
+ *
+ * Given the scenario above, when a process interrupt signal is received, the primary can exit before the workers
+ * have gracefully shutdown (e.g.; http connections to function still open). If this happens the worker processes
+ * become children of the process that executed the `sf` command. These workers will continue to run until graceful or
+ * forced shutdown causes them to eventually exit.
+ *
+ * Only call this when capturing output is no longer required (i.e.; shutdown)
+ */
+function maybeStopLogging(logger, host) {
+  // limit this to localhost only which is really the only place the behavior described above is observed
+  if (host === "localhost") {
+    logger.getBunyanLogger().streams = [];
+  }
+}

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ChildProcess, spawn } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+import { expect } from "chai";
+import { request } from "http";
+
+type FunctionProcess = {
+  childProcess: ChildProcess;
+  processInvoked: Promise<void>;
+  processClosed: Promise<{
+    output: string;
+    code: number;
+  }>;
+};
+
+type InvocationRequest = {
+  responseReceived: Promise<{
+    body: string;
+    statusCode: number;
+  }>;
+};
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+const PORT = 8000;
+const ONE_SECOND = 1000;
+const SECONDS = ONE_SECOND;
+const GRACE_PERIOD = 1000;
+
+describe("cli shutdown routine", function () {
+  this.timeout(30 * SECONDS);
+
+  let functionProcess: FunctionProcess;
+  let invocationRequest: InvocationRequest;
+
+  afterEach(() => {
+    try {
+      if (
+        functionProcess &&
+        functionProcess.childProcess &&
+        functionProcess.childProcess.pid
+      ) {
+        process.kill(functionProcess.childProcess.pid, "SIGTERM");
+      }
+    } catch (ignored) {
+      // just silently move on
+    }
+  });
+
+  it("should exit gracefully", async function () {
+    await startAndInvokeFunctionThenShutdown({
+      timeToCleanlyShutdown: Math.floor(GRACE_PERIOD / 2),
+    });
+  });
+
+  it("should exit forcefully if the function has not completed before the grace period is reached", async function () {
+    await startAndInvokeFunctionThenShutdown({
+      timeToCleanlyShutdown: GRACE_PERIOD * 2,
+    });
+  });
+
+  async function startAndInvokeFunctionThenShutdown(options: {
+    timeToCleanlyShutdown: number;
+  }) {
+    if (process.platform === "win32") {
+      // This test won't work on Windows system due to the following:
+      // > On Windows, where POSIX signals do not exist, the signal argument will be ignored, and the process will be
+      // > killed forcefully and abruptly (similar to 'SIGKILL').
+      // (from https://nodejs.org/api/child_process.html#subprocesskillsignal)
+      return Promise.resolve();
+    }
+
+    const timeToCleanlyShutdown = options.timeToCleanlyShutdown;
+
+    await startFunction({ timeToCleanlyShutdown });
+    await invokeFunction();
+    await killFunctionProcess("SIGINT");
+
+    const { code, output } = await functionProcess.processClosed;
+    expect(code).to.equal(0);
+    expect(output).to.include("function worker exiting; received SIGINT");
+
+    try {
+      const { statusCode, body } = await invocationRequest.responseReceived;
+      expect(body).to.include('[{"complete":true}]');
+      expect(statusCode).to.equal(200);
+      expect(timeToCleanlyShutdown).to.be.lessThan(GRACE_PERIOD);
+    } catch (ignored) {
+      expect(timeToCleanlyShutdown).to.be.greaterThan(GRACE_PERIOD);
+    }
+  }
+
+  function startFunction(options: { timeToCleanlyShutdown: number }) {
+    const node = process.argv[0];
+    const cliScript = path.resolve(__dirname, "..", "bin", "dev.js");
+    const args = [
+      "--loader",
+      "ts-node/esm",
+      cliScript,
+      "serve",
+      fixture("long-running-function"),
+      "-h",
+      "localhost",
+      "-p",
+      `${PORT}`,
+      "-w",
+      "1",
+      "-g",
+      `${GRACE_PERIOD}`,
+    ];
+
+    const childProcess = spawn(node, args, {
+      detached: true,
+      cwd: path.resolve(__dirname, ".."),
+      env: {
+        ...process.env,
+        LONG_RUNNING_PROCESS_TIMEOUT: `${options.timeToCleanlyShutdown}`,
+      },
+    });
+
+    let output = "";
+    return new Promise<FunctionProcess>((resolve) => {
+      childProcess.stdout.on("data", (data) => {
+        process.stdout.write(`[function] ${data}`);
+        output += data;
+        if (output.includes("started function worker")) {
+          resolve({
+            childProcess,
+            processInvoked: new Promise((resolve) => {
+              childProcess.stdout.on("data", () => {
+                if (output.includes("Simulating a long running process")) {
+                  resolve();
+                }
+              });
+            }),
+            processClosed: new Promise((resolve) => {
+              childProcess.on("close", (code) => {
+                resolve({ output, code });
+              });
+            }),
+          });
+        }
+      });
+    }).then((result) => {
+      functionProcess = result;
+    });
+  }
+
+  function invokeFunction() {
+    let body = "";
+
+    const payload = JSON.stringify({});
+
+    const req = request({
+      hostname: "localhost",
+      port: PORT,
+      path: "/",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(payload),
+        "ce-specversion": "1.0",
+        "ce-id": `00Dxx0000006IYJEA2-4Y4W3Lw_LkoskcHdEaZze--TEST-${Date.now()}`,
+        "ce-source":
+          "urn:event:from:salesforce/xx/228.0/00Dxx0000006IYJ/apex/MyFunctionApex:test():7",
+        "ce-type": "com.salesforce.function.invoke.sync",
+        "ce-time": "2020-09-03T20:56:28.297915Z",
+        "ce-sfcontext":
+          "eyJhcGlWZXJzaW9uIjoiNTAuMCIsInBheWxvYWRWZXJzaW9uIjoiMC4xIiwidXNlckNvbnRleHQiOnsib3JnSWQiOiIwMER4eDAwMDAwMDZJWUoiLCJ1c2VySWQiOiIwMDV4eDAwMDAwMVg4VXoiLCJvbkJlaGFsZk9mVXNlcklkIjpudWxsLCJ1c2VybmFtZSI6InRlc3QtenFpc25mNnl0bHF2QGV4YW1wbGUuY29tIiwic2FsZXNmb3JjZUJhc2VVcmwiOiJodHRwOi8vcGlzdGFjaGlvLXZpcmdvLTEwNjMtZGV2LWVkLmxvY2FsaG9zdC5pbnRlcm5hbC5zYWxlc2ZvcmNlLmNvbTo2MTA5Iiwib3JnRG9tYWluVXJsIjoiaHR0cDovL3Bpc3RhY2hpby12aXJnby0xMDYzLWRldi1lZC5sb2NhbGhvc3QuaW50ZXJuYWwuc2FsZXNmb3JjZS5jb206NjEwOSJ9fQ==",
+        "ce-sffncontext":
+          "eyJhY2Nlc3NUb2tlbiI6IjAwRHh4MDAwMDAwNklZSiFBUUVBUU5SYWM1YTFoUmhoZjAySFJlZ3c0c1NadktoOW9ZLm9oZFFfYV9LNHg1ZHdBZEdlZ1dlbVhWNnBOVVZLaFpfdVkyOUZ4SUVGTE9adTBHZjlvZk1HVzBIRkxacDgiLCJmdW5jdGlvbkludm9jYXRpb25JZCI6bnVsbCwiZnVuY3Rpb25OYW1lIjoiTXlGdW5jdGlvbiIsImFwZXhDbGFzc0lkIjpudWxsLCJhcGV4Q2xhc3NGUU4iOm51bGwsInJlcXVlc3RJZCI6IjAwRHh4MDAwMDAwNklZSkVBMi00WTRXM0x3X0xrb3NrY0hkRWFaemUtLU15RnVuY3Rpb24tMjAyMC0wOS0wM1QyMDo1NjoyNy42MDg0NDRaIiwicmVzb3VyY2UiOiJodHRwOi8vZGhhZ2Jlcmctd3NsMTo4MDgwIn0=",
+        Authorization:
+          "C2C eyJ2ZXIiOiIxLjAiLCJraWQiOiJDT1JFLjAwRHh4MDAwMDAwNklZSi4xNTk5MTU5NjQwMzUwIiwidHlwIjoiand0IiwiY2x2IjoiSjIuMS4xIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOiJwbGF0Zm9ybS1mdW5jdGlvbnMiLCJhdXQiOiJTRVJWSUNFIiwibmJmIjoxNTk5MTY2NTU4LCJjdHgiOiJzZmRjLnBsYXRmb3JtLWZ1bmN0aW9ucyIsImlzcyI6ImNvcmUvZGhhZ2Jlcmctd3NsMS8wMER4eDAwMDAwMDZJWUpFQTIiLCJzdHkiOiJUZW5hbnQiLCJpc3QiOjEsImV4cCI6MTU5OTE2NjY3OCwiaWF0IjoxNTk5MTY2NTg4LCJqdGkiOiJDMkMtMTA3NTg2OTg1NTMxNTMyOTkzMjE3OTEyMzQwNTIzMjgzOTEifQ.jZZ4ksYlq0vKtBf0yEfpJVL2yYh3QHOwp0KCk-QxzDyF_7VARB-N74Cqpj2JWhVP4TcBLGXYuldB-Sk6P5HlGQ",
+      },
+    });
+
+    return new Promise<InvocationRequest>((resolve) => {
+      req.write(payload);
+      req.end(() => {
+        resolve({
+          responseReceived: new Promise((resolve, reject) => {
+            req.on("error", reject);
+            req.on("response", (res) => {
+              const statusCode = res.statusCode;
+              res.setEncoding("utf8");
+              res.on("data", (chunk) => (body += chunk));
+              res.on("error", reject);
+              res.on("end", () => resolve({ statusCode, body }));
+            });
+          }),
+        });
+      });
+    }).then((result) => {
+      invocationRequest = result;
+    });
+  }
+
+  async function killFunctionProcess(signal: NodeJS.Signals) {
+    await functionProcess.processInvoked;
+    functionProcess.childProcess.kill(signal);
+    return new Promise((resolve) => {
+      setTimeout(resolve, GRACE_PERIOD + ONE_SECOND);
+    });
+  }
+});
+
+function fixture(name) {
+  return path.resolve(__dirname, "..", "fixtures", name);
+}


### PR DESCRIPTION
While implementing changes related to [heroku/sf-functions-core#45](https://github.com/heroku/sf-functions-core/pull/45) I noticed that worker processes could become orphaned when the primary process is forcefully killed.

The [`throng`](https://github.com/hunterloftis/throng) makes reference to this potential behavior [here](https://github.com/hunterloftis/throng/blob/5dc2ac054d1cedc94188f3a8372914368ebf9cce/lib/throng.js#L68-L77).  The implication of this is that worker processes need to properly implement their own graceful/forced shutdown routines.

This PR uses the same `grace` period from the primary process to configure each worker process.  The worker will wait for any outstanding http requests to finish before cleanly shutting down.  If the worker cannot cleanly shutdown before exceeding the `grace` period then the worker will then be forced to shut down.

[GUS-W-10819415](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000sOC4iYAG/view)