### PR TITLE
Prepare 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.2] - 2022-06-29
 - Update to enable Salesforce API version v55.0
 
 ## [0.11.1] - 2022-04-01

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {


### PR DESCRIPTION
This prepares version 0.11.2. 

Enabling Salesforce Api v55.0 [#357](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/357)

[W-11363129](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE000010IICzYAO)