### PR TITLE
Silence deprecation warning from fastify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Update publish.sh 
+- Packaged releases no longer available from s3 (#[362](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/362))
+- Silence deprecation warning from fastify (#[393](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/393))
 
 ## [0.11.2] - 2022-06-29
 - Update to enable Salesforce API version v55.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Packaged releases no longer available from s3 (#[362](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/362))
-- Silence deprecation warning from fastify (#[393](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/393))
+- Packaged releases no longer available from s3 ([#362](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/362))
+- Silence deprecation warning from fastify ([#393](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/393))
 
 ## [0.11.2] - 2022-06-29
 - Update to enable Salesforce API version v55.0

--- a/src/server.ts
+++ b/src/server.ts
@@ -167,7 +167,7 @@ export default async function startServer(
   registerShutdownHooks({ server, disconnect, grace, signals, logger, host });
 
   try {
-    await server.listen(port, host);
+    await server.listen({ port, host });
     logger.info(`started function worker ${id}`);
   } catch (err) {
     logger.error(`error starting function worker ${id}: ${err}`);


### PR DESCRIPTION
The following message has been appearing in function logs:

[FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.

Upstream issue and discussion: https://github.com/fastify/fastify/issues/3652

Fixes #385 

[GUS](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE000014vMxvYAE)