### PR TITLE
Fix isReferenceId(null) typecheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- Fix `isReferenceId(null)` type check ([#401](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/401))
 - Packaged releases no longer available from s3 ([#362](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/362))
 - Silence deprecation warning from fastify ([#393](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/393))
 

--- a/mappings/composite-graph-create.json
+++ b/mappings/composite-graph-create.json
@@ -6,7 +6,7 @@
     "method": "POST",
     "bodyPatterns": [
       {
-        "equalToJson": "{\n    \"graphs\": [\n        {\n            \"graphId\": \"graph0\",\n            \"compositeRequest\": [\n                {\n                    \"url\": \"/services/data/v51.0/sobjects/Movie__c\",\n                    \"method\": \"POST\",\n                    \"referenceId\": \"insert-anh\",\n                    \"body\": {\n                        \"Name\": \"Star Wars Episode IV - A New Hope\",\n                        \"Rating__c\": \"Excellent\"\n                    }\n                }\n            ]\n        }\n    ]\n}"
+        "equalToJson": "{ \"graphs\": [ { \"graphId\": \"graph0\", \"compositeRequest\": [ { \"url\": \"/services/data/v51.0/sobjects/Movie__c\", \"method\": \"POST\", \"referenceId\": \"insert-anh\", \"body\": { \"Name\": \"Star Wars Episode IV - A New Hope\", \"Rating__c\": \"Excellent\", \"ReleaseDate__c\": null } } ] } ]}"
       }
     ],
     "headers": {

--- a/src/sdk/sub-request.ts
+++ b/src/sdk/sub-request.ts
@@ -141,5 +141,5 @@ function expandReferenceIds(fields: { [key: string]: unknown }): {
 }
 
 function isReferenceId(val: any): val is ReferenceId {
-  return (val as ReferenceId).toApiString !== undefined;
+  return val && typeof val === 'object' && 'toApiString' in val && 'toString' in val;
 }

--- a/src/sdk/sub-request.ts
+++ b/src/sdk/sub-request.ts
@@ -141,5 +141,7 @@ function expandReferenceIds(fields: { [key: string]: unknown }): {
 }
 
 function isReferenceId(val: any): val is ReferenceId {
-  return val && typeof val === 'object' && 'toApiString' in val && 'toString' in val;
+  return (
+    val && typeof val === "object" && "toApiString" in val && "toString" in val
+  );
 }

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -510,6 +510,7 @@ describe("DataApi Class", async () => {
             fields: {
               Name: "Star Wars Episode IV - A New Hope",
               Rating__c: "Excellent",
+              ReleaseDate__c: null,
             },
           });
 
@@ -570,7 +571,6 @@ describe("DataApi Class", async () => {
             type: "Franchise__c",
             fields: {
               Name: "Star Wars",
-              ReleaseDate__c: null,
             },
           });
 

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -570,6 +570,7 @@ describe("DataApi Class", async () => {
             type: "Franchise__c",
             fields: {
               Name: "Star Wars",
+              ReleaseDate__c: null,
             },
           });
 


### PR DESCRIPTION
Field values with a `null` such as the following will throw an error.

```js
const uow = context.org.dataApi.newUnitOfWork();
const caseId = uow.registerUpdate({
  type: "Case",
  fields: {
    id: '1234',
    Subject: "Test Update Case ",
    Description: null
  },
});
```
The error thrown is `Cannot read properties of undefined (reading 'toApiString')`. This PR protects against that and adds this scenario to the test suite.

GUS-W-11687356
GUS-W-11566044
