### PR TITLE
Switch baseURL to orgDomainUrl rather than salesforceBaseUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Default url for DataAPI is now `orgDomainUrl` rather than `salesforceBaseUrl` ([#417](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/417))
 - Update to cloudevents 6.0 ([#402](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/402))
 - Fix `isReferenceId(null)` type check ([#401](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/401))
 - Packaged releases no longer available from s3 ([#362](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/362))

--- a/src/sdk/org.ts
+++ b/src/sdk/org.ts
@@ -41,7 +41,11 @@ export class OrgImpl implements Org {
     this.domainUrl = orgDomainUrl;
     this.apiVersion = salesforceApiVersion;
 
-    this.dataApi = new DataApiImpl(this.domainUrl, this.apiVersion, accessToken);
+    this.dataApi = new DataApiImpl(
+      this.domainUrl,
+      this.apiVersion,
+      accessToken
+    );
     this.user = new UserImpl(userId, username, onBehalfOfUserId);
   }
 }

--- a/src/sdk/org.ts
+++ b/src/sdk/org.ts
@@ -41,7 +41,7 @@ export class OrgImpl implements Org {
     this.domainUrl = orgDomainUrl;
     this.apiVersion = salesforceApiVersion;
 
-    this.dataApi = new DataApiImpl(this.baseUrl, this.apiVersion, accessToken);
+    this.dataApi = new DataApiImpl(this.domainUrl, this.apiVersion, accessToken);
     this.user = new UserImpl(userId, username, onBehalfOfUserId);
   }
 }


### PR DESCRIPTION
We're using the salesforceBaseUrl which could be a Visualforce Site URL, eg “https://reachfinancial.my.salesforce-sites.com/services/function/asyncResponseHandler”. `orgDomainUrl` is more appropriate.

Slack thread: https://heroku.slack.com/archives/C01R6FJ738U/p1664223302584279

GUS-W-11819225