### PR TITLE
Prepare version 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2022-09-28
+
 - Automatic handling of base64 / binary data via binaryFields ([#400](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/400))
 - Default url for DataAPI is now `orgDomainUrl` rather than `salesforceBaseUrl` ([#417](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/417))
 - Update to cloudevents 6.0 ([#402](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/402))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/sf-fx-runtime-nodejs",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "type": "module",
   "description": "A web server that takes in function source code and provides the Salesforce FX SDK to the invoked source code.",
   "scripts": {


### PR DESCRIPTION
This will release #400, #417, #402, #401, #393 as well as several dependency updates.

GUS-W-11543492