### PR TITLE
Fix parse of query with nested record data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix parsing of query results to include nested `Record` fields ([#451](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/451))
 
 ## [0.14.0] - 2022-11-29
 - Improved [Relationship Queries](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_relationships.htm) support for results returned by `dataApi.query("...")`

--- a/mappings/query-with-associated-data.json
+++ b/mappings/query-with-associated-data.json
@@ -1,0 +1,31 @@
+{
+  "id": "fb30aeaf-08a7-4cbc-b4c0-50fc034c1409",
+  "name": "services_data_v550_query",
+  "request": {
+    "url": "/services/data/v55.0/query?q=SELECT%20Name%2C%20Owner.Name%20from%20Account%20LIMIT%201",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"totalSize\":1,\"done\":true,\"records\":[{\"attributes\":{\"type\":\"Account\",\"url\":\"/services/data/v53.0/sobjects/Account/001B000001PUvQUIA1\"},\"Name\":\"TestAccount5\",\"Owner\":{\"attributes\":{\"type\":\"User\",\"url\":\"/services/data/v53.0/sobjects/User/005B0000008UC2PIAW\"},\"Name\":\"Guy Smiley\"}}]}",
+    "headers": {
+      "Date": "Fri, 02 Dec 2022 18:02:55 GMT",
+      "Set-Cookie": [
+        "CookieConsentPolicy=0:1; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000",
+        "LSKey-c$CookieConsentPolicy=0:1; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000",
+        "BrowserId=jA2SIXJrEe2HE63eO1gD5Q; domain=.salesforce.com; path=/; expires=Sat, 02-Dec-2023 18:02:55 GMT; Max-Age=31536000"
+      ],
+      "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "X-Robots-Tag": "none",
+      "Cache-Control": "no-cache,must-revalidate,max-age=0,no-store,private",
+      "Sforce-Limit-Info": "api-usage=11/100000",
+      "Content-Type": "application/json;charset=UTF-8",
+      "Vary": "Accept-Encoding"
+    }
+  },
+  "uuid": "fb30aeaf-08a7-4cbc-b4c0-50fc034c1409",
+  "persistent": true,
+  "insertionIndex": 3
+}

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -303,7 +303,11 @@ async function buildQueriedRecord(
       binaryFields[key] = await eagerlyLoadBinaryField(conn, type, key, val);
       fields[key] = val;
     } else if (typeof val === "object") {
-      subQueryResults[key] = await buildSubQueryResult(conn, key, val);
+      if ("attributes" in val) {
+        fields[key] = await buildQueriedRecord(conn, val);
+      } else {
+        subQueryResults[key] = await buildSubQueryResult(conn, key, val);
+      }
     } else if (val) {
       fields[key] = val;
     }


### PR DESCRIPTION
Changes the routine that parses query results to differentiate between:
* sub-query result sets
* nested record data from associated records

[W-12157407](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001FgcRDYAZ/view)