### PR TITLE
Make `fsevents` dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Marking `fsevents` as an optional dependency for this library to prevent it from being treated as non-optional
+  within function projects, causing a `EBADPLATFORM` error in NPM
 
 ## [0.14.1] - 2022-12-05
 - Fix parsing of query results to include nested `Record` fields ([#451](https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/451))

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -45,6 +45,9 @@
         "typedoc-plugin-markdown": "^3.10.4",
         "typescript": "^4.4.2",
         "wiremock": "^2.29.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "*"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2778,7 +2781,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -8409,7 +8411,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "typescript": "^4.4.2",
     "wiremock": "^2.29.0"
   },
+  "optionalDependencies": {
+    "fsevents": "*"
+  },
   "bin": {
     "sf-fx-runtime-nodejs": "bin/cli.js"
   }

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -35,7 +35,7 @@ const SECONDS = ONE_SECOND;
 const GRACE_PERIOD = 1000;
 
 describe("cli shutdown routine", function () {
-  this.timeout(30 * SECONDS);
+  this.timeout(60 * SECONDS);
 
   let functionProcess: FunctionProcess;
   let invocationRequest: InvocationRequest;


### PR DESCRIPTION
- also bumps the timeout for the cli shutdown test which causes intermittent failures in GHA

The problem here is the use of `npm-shinkwrap.json` instead of `package-lock.json` in the runtime module. It causes the `fsevents` module to be installed as a non-optional dependency when `@heroku/sf-fx-runtime-nodejs` is listed in a function's `package.json` dependencies on Mac machines.

We use `npm-shrinkwrap.json` currently so that the Node Function CNB can install the runtime module globally in functions that do not have an explicit dependency on the runtime. Normally a `package-lock.json` file is the preferred way to pin dependency versions but that doesn't work for globally installed packages like command line utilities. The `npm-shrinkwrap.json` file is made for this "global install" use case.

The `fsevents` module is a Mac-only dependency and is typically flagged as optional for modules that use it which allows for non-Mac system to use those modules. This should be true for `@heroku/sf-fx-runtime-nodejs` as well since it doesn't directly depend on this module but it is a transitive dependency of the `mocha` development dependency. For whatever reason, using `npm-shrinkwrap.json` causes the optional information to be lost.

Switching to the more standard `package-lock.json` format in `@heroku/sf-fx-runtime-nodejs` fixes this problem but we can't make that change until we release a breaking change to our runtime module (e.g.; like bulk api support) and that won't happen for another month or so.

[W-12213086](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001HOIOdYAP/view)