### PR TITLE
Ignore risky updates in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      # updating this dependency has caused issues in the past, we should only touch this if there is an update for security purposes
+      - dependency-name: "cloudevents"
+      # updating this dependency has caused issues in the past, we should only touch this if there is an update for security purposes
+      - dependency-name: "jsforce2"
+      # due to the version of jsforce used, typescript complains loudly if the node types are bumped
+      - dependency-name: "@types/node"
+      # we're already at the highest version we can migrate to without requiring major changes to the logger
+      # see https://github.com/forcedotcom/sfdx-core/blob/main/MIGRATING_V4-V5.md
+      - dependency-name: "@salesforce/core"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This should cut down on noise from dependencies we shouldn't touch unless there is a very good reason to.