### PR TITLE
Group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # updating this dependency has caused issues in the past, we should only touch this if there is an update for security purposes
       - dependency-name: "cloudevents"


### PR DESCRIPTION
Adding configuration to dependabot to take advantage of [group updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).

[GUS-W-13579117](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13579117)